### PR TITLE
Bugfix for QCG

### DIFF
--- a/src/confparse.f90
+++ b/src/confparse.f90
@@ -2199,7 +2199,7 @@ subroutine inputcoords(env,arg)
   integer :: i
 
 !>--- Redirect for QCG input reading
-  if (env%crestver == crest_solv) then
+  if (env%QCG) then
     arg2 = env%solv_file
     call inputcoords_qcg(env,arg,arg2)
     return
@@ -2236,7 +2236,7 @@ subroutine inputcoords(env,arg)
   !call rdnat('coord',env%nat)
   call mol%open('coord')
   !> shift to CMA and align according to rot.const.
-  call axis(mol%nat,mol%at,mol%xyz)
+  if(env%crestver /= crest_solv) call axis(mol%nat,mol%at,mol%xyz)
   !> overwrite coord
   call mol%write('coord')
 

--- a/src/qcg/solvtool.f90
+++ b/src/qcg/solvtool.f90
@@ -859,9 +859,9 @@ subroutine qcg_ensemble(env,solu,solv,clus,ens,tim,fname_results)
   call rdcoord('solvent_shell.coord',clus%nat,clus%at,clus%xyz)
   end if
 
-  env%crestver=crest_imtd2
+  env%QCG = .false. !For newcregen: If env%crestver .eq. crest_solv .and. .not. env%QCG then conffile .eq. .true.
+
   call inputcoords(env,'crest_input')
-  env%crestver=crest_solv
   call iV2defaultGF(env)         !Setting MTD parameter
 
 !--- Special constraints for gff to safeguard stability
@@ -897,9 +897,7 @@ subroutine qcg_ensemble(env,solu,solv,clus,ens,tim,fname_results)
 
       env%iterativeV2 = .true.  !Safeguards more precise ensemble search
       write(*,*) 'Starting ensemble cluster generation by CREST routine'
-      env%QCG = .false. !For newcregen: If env%crestver .eq. crest_solv .and. .not. env%QCG then conffile .eq. .true.
       call confscript2i(env,tim) !Calling ensemble search
-      env%QCG = .true.
       call copy('crest_rotamers.xyz','crest_rotamers_0.xyz')
 
     case( 1:2 ) ! Single MD or MTD
@@ -1101,15 +1099,15 @@ subroutine qcg_ensemble(env,solu,solv,clus,ens,tim,fname_results)
          call dum%deallocate
          call chdir(tmppath2)
          call wrc0('coord',clus%nat,clus%at,clus%xyz)
-         env%crestver=crest_imtd2
          call inputcoords(env,'coord') !Necessary
-         env%crestver=crest_solv
 
 !--- Optimization
          call print_qcg_opt
          if(env%gfnver .eq. '--gfn2') call multilevel_opt(env,99)    
 
   end select
+
+  env%QCG = .true.
 
 !--- Optimization with gfn2 if necessary
   gfnver_tmp = env%gfnver

--- a/src/qcg/volume.f90
+++ b/src/qcg/volume.f90
@@ -112,7 +112,9 @@ subroutine create_neigh(nat, xyz_rad, neigh_list, neigh_index, neigh_type)
          neigh_index(i + 1) = neigh_index(i)
       !--- Neighbors
       else
-         neigh_index(i + 1) = neigh_index(i) + neigh_list(i)
+         if(i < nat) then
+            neigh_index(i + 1) = neigh_index(i) + neigh_list(i)
+         end if
          do j = 1, neigh_list(i)
             neigh_type(neigh_index(i) + j - 1) = neigh_tmp(j)
          end do


### PR DESCRIPTION
- Fixes a Bug in the crest version 2.12 that lead to a crash of the ensemble generation during the QCG run
- Fixes a Bug regarding the QCG when compiling with gfortran. This also affects builds with conda