### PR TITLE
Fix GitHub workflows build (use ifort 2022.2.1 instead of latest)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,7 @@ jobs:
 
     - name: Install github-release
       run: |
-        go get github.com/github-release/github-release
+        go install github.com/github-release/github-release
         echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
         echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,8 +65,16 @@ jobs:
     - name: Install package
       run: |
         meson install -C ${{ env.BUILD_DIR }} --no-rebuild
+        tar cJvf crest-latest.tar.xz ${{ env.PWD }}/_dist/bin/crest
       env:
         DESTDIR: ${{ env.PWD }}/_dist
+
+    - name: Upload binary
+      if: github.event_name == 'push'
+      uses: actions/upload-artifact@v2
+      with:
+        name: crest-latest.tar.xz
+        path: crest-latest.tar.xz
 
     - name: Add crest to path
       run: |
@@ -99,15 +107,15 @@ jobs:
 
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      RELEASE_TAG: cont
-      OUTPUT_INTEL: crest-continous.tar.xz
+      RELEASE_TAG: latest
+      OUTPUT_INTEL: crest-latest.tar.xz
 
     steps:
     - uses: actions/checkout@v2
 
     - name: Install github-release
       run: |
-        go install github.com/github-release/github-release
+        go install github.com/github-release/github-release@latest
         echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
         echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
@@ -155,7 +163,7 @@ jobs:
         cd ${{ env.OUTPUT_INTEL }}
         sha256sum ${{ env.OUTPUT_INTEL }} > sha256.txt
 
-    - name: Add ${{ env.OUTPUT_INTEL }} to release tag
+    - name: Add crest-latest to release tag
       run: >-
         github-release upload
         --tag ${{ env.RELEASE_TAG }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       CC: ${{ matrix.cc }}
       APT_PACKAGES: >-
         intel-oneapi-compiler-fortran-2022.2.1
-        intel-oneapi-compiler-dpcpp-cpp-2022.2.1
+        intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2022.2.1
         intel-oneapi-mkl-2022.2.1
         intel-oneapi-mkl-devel-2022.2.1
 #      APT_PACKAGES: >-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,15 @@ jobs:
       FC: ${{ matrix.fc }}
       CC: ${{ matrix.cc }}
       APT_PACKAGES: >-
-        intel-oneapi-compiler-fortran
-        intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
-        intel-oneapi-mkl
-        intel-oneapi-mkl-devel
+        intel-oneapi-compiler-fortran-2022.2.1
+        intel-oneapi-compiler-dpcpp-cpp-2022.2.1
+        intel-oneapi-mkl-2022.2.1
+        intel-oneapi-mkl-devel-2022.2.1
+#      APT_PACKAGES: >-
+#        intel-oneapi-compiler-fortran
+#        intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+#        intel-oneapi-mkl
+#        intel-oneapi-mkl-devel
 
     steps:
     - name: Checkout code
@@ -84,3 +89,85 @@ jobs:
 #      run: |
 #        bash run.sh
 #      working-directory: examples/expl-0
+
+
+  continuous-delivery:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    needs:
+      - intel-meson-build
+
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      RELEASE_TAG: cont
+      OUTPUT_INTEL: crest-continous.tar.xz
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install github-release
+      run: |
+        go get github.com/github-release/github-release
+        echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+        echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+
+    - name: Set environment variables
+      run: |
+        echo "GITHUB_USER=$( echo ${{ github.repository }} | cut -d/ -f1 )" >> $GITHUB_ENV
+        echo "GITHUB_REPO=$( echo ${{ github.repository }} | cut -d/ -f2 )" >> $GITHUB_ENV
+
+    - name: Move/Create continuous tag
+      run: |
+        git tag --force ${{ env.RELEASE_TAG }} ${{ github.sha }}
+        git push --tags --force
+
+    - name: Get Time
+      run: echo "TIME=$(date -u '+%Y/%m/%d, %H:%M')" >> $GITHUB_ENV
+
+    - name: Check continuous release status
+      run: |
+        if ! github-release info -t ${{ env.RELEASE_TAG }} > /dev/null 2>&1; then
+          echo "RELEASE_COMMAND=release" >> $GITHUB_ENV
+        else
+          echo "RELEASE_COMMAND=edit" >> $GITHUB_ENV
+        fi
+
+    - name: Setup continuous release
+      run: >-
+        github-release ${{ env.RELEASE_COMMAND }}
+        --tag ${{ env.RELEASE_TAG }}
+        --name "Continous release version"
+        --description "$DESCRIPTION"
+        --pre-release
+      env:
+        DESCRIPTION: |
+          Created on ${{ env.TIME }} UTC by @${{ github.actor }} with commit ${{ github.sha }}.
+          This is an automated distribution of the latest CREST version. This version is only minimally tested and may be unstable or even crash. Use with caution!
+          https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+    - name: Download Artifacts
+      uses: actions/download-artifact@v2
+      with:
+        path: ${{ github.workspace }} # This will download all files
+
+    - name: Create SHA256 checksum
+      run: |
+        cd ${{ env.OUTPUT_INTEL }}
+        sha256sum ${{ env.OUTPUT_INTEL }} > sha256.txt
+
+    - name: Add ${{ env.OUTPUT_INTEL }} to release tag
+      run: >-
+        github-release upload
+        --tag ${{ env.RELEASE_TAG }}
+        --replace
+        --name ${{ env.OUTPUT_INTEL }}
+        --file ${{ env.OUTPUT_INTEL }}/${{ env.OUTPUT_INTEL }}
+
+    - name: Add SHA256 checksums to release tag
+      run: >-
+        github-release upload
+        --tag ${{ env.RELEASE_TAG }}
+        --replace
+        --name sha256.txt
+        --file ${{ env.OUTPUT_INTEL }}/sha256.txt
+                                                     

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Install package
       run: |
         meson install -C ${{ env.BUILD_DIR }} --no-rebuild
-        tar cJvf crest-latest.tar.xz ${{ env.PWD }}/_dist/bin/crest
+        tar cJvf crest-latest.tar.xz --directory=${{ env.BUILD_DIR }} crest
       env:
         DESTDIR: ${{ env.PWD }}/_dist
 
@@ -150,7 +150,9 @@ jobs:
       env:
         DESCRIPTION: |
           Created on ${{ env.TIME }} UTC by @${{ github.actor }} with commit ${{ github.sha }}.
-          This is an automated distribution of the latest CREST version. This version is only minimally tested and may be unstable or even crash. Use with caution!
+          This is an automated distribution of the latest CREST version. 
+          This version is only minimally tested and may be unstable or even crash. 
+          Use with caution!
           https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
     - name: Download Artifacts


### PR DESCRIPTION
This fixes the latest GitHub workflows build and adds a continuous release job to it.
The continuous release will be found at https://github.com/crest-lab/crest/releases/tag/latest