### PR TITLE
Added --wall, --wall-xl, and --wall-xxl options

### DIFF
--- a/src/classes.f90
+++ b/src/classes.f90
@@ -506,6 +506,7 @@ module crest_data
       logical :: user_wscal =.false. !true if wscal is set by user
       logical :: useqmdff          ! use QMDFF in V2?
       logical :: water = .false.   ! true if water is used as solvent (only QCG)
+      logical :: wallsetup = .false. ! set up a wall potential?
       logical :: wbotopo =.false.  ! set up topo with WBOs   
 
     contains

--- a/src/confparse.f90
+++ b/src/confparse.f90
@@ -806,6 +806,17 @@ subroutine parseflags(env,arg,nra)
         case ('-wscal')                           !scale size of wall potential
           call readl(arg(i + 1),xx,j)
           env%potscal = xx(1)
+        case ('-wall')
+          env%wallsetup = .true.
+          write (*,'(2x,a,1x,a)')'--wall:','requesting setup of wall potential'
+        case ( '-wallxl','-wall-xl')
+          env%wallsetup = .true.
+          env%potscal = 1.5_wp
+          write (*,'(2x,a,1x,a)')'--wall-xl:','requesting setup of wall potential (x1.5 size)'
+        case ( '-wallxxl','-wall-xxl') 
+          env%wallsetup = .true.
+          env%potscal = 2.0_wp
+          write (*,'(2x,a,1x,a)')'--wall-xxl:','requesting setup of wall potential (x2.0 size)'
         case ('-squick','-superquick')            !extremely crude quick mode
           write (*,'(2x,a,1x,a)') trim(arg(i)),' : very crude quick-mode (no NORMMD, no GC, crude opt.)'
           env%rotamermds = .false.      !no NORMMD
@@ -1866,9 +1877,13 @@ subroutine parseflags(env,arg,nra)
     error stop 'Z sorting of the input is unavailable for -qcg runtyp.'
   end if
 
-  if (env%NCI) then
+  if (env%NCI .or. env%wallsetup) then
     call wallpot(env)
+    if(env%wallsetup)then
+    write(*,'(2x,a)') 'Automatically generated ellipsoide potential:'
+    else
     write (*,'(2x,a)') 'Automatically generated ellipsoide potential for NCI mode:'
+    endif
     call write_cts_NCI_pr(6,env%cts)
     write (*,*)
   end if

--- a/src/ncigeo.f90
+++ b/src/ncigeo.f90
@@ -46,7 +46,8 @@ subroutine wallpot(env)
 
   allocate (env%cts%pots(10))
   env%cts%pots = ''
-  env%cts%NCI = env%NCI
+  !env%cts%NCI = env%NCI
+  env%cts%NCI = .true.
 
   pshape = 1.0d0
 
@@ -58,24 +59,16 @@ subroutine wallpot(env)
   call rdcoord('coord',nat,at,xyz)
 
 !--- CMA trafo
-  !call axistrf(nat,nat,at,xyz)
-  !call axis(nat,at,xyz) 
   call axis(pr,nat,at,xyz,eaxr)
   sola = sqrt(1.0d0 + (abs(eaxr(1) - eaxr(3))) / (abs(eaxr(1) + eaxr(2) + eaxr(3)) / 3.0d0))
   call getmaxdist(nat,xyz,at,rmax)
   vtot = volsum(nat,at) !--- volume as sum of speherical atoms (crude approximation)
 
 !--- calculate ellipsoid
-
-  !env%potscal
   roff = sola * vtot / 1000.0d0
-  !write(*,*) 'roff',roff
   boxr = ((sola * vtot) / pi43)**third + roff + rmax * 0.5_wp
-  !write(*,*) 'boxr',boxr
   r = (boxr**3 / (eaxr(1) * eaxr(2) * eaxr(3)))**third  ! volume of ellipsoid = volume of sphere
-  !write(*,*) 'r',r
   rabc = eaxr**pshape / sum((eaxr(1:3))**pshape)
-  !write(*,*) 'rabc',rabc
 
   !> scale pot size by number of atoms
   !> pure empirics
@@ -85,7 +78,6 @@ subroutine wallpot(env)
   !> erfscal is ~ 1.25 for systems <<50 atoms
   !> erfscal is ~ 0.75 for systems >>50 atoms
   rabc = eaxr * r * env%potscal * erfscal * 1.5_wp
-  !write(*,*) 'rabc',rabc
 
 !--- write CMA transformed coord file
   call wrc0('coord',env%nat,at,xyz)
@@ -126,11 +118,10 @@ subroutine wallpot_calc(nat,at,xyz,rabc)
   eaxr = 0.0d0
 
 !--- CMA trafo
-  !call axistrf(nat,nat,at,xyz)
   call axis(pr,nat,at,xyz,eaxr)
   sola = sqrt(1.0d0 + (eaxr(1) - eaxr(3)) / ((eaxr(1) + eaxr(2) + eaxr(3)) / 3.0d0))
   call getmaxdist(nat,xyz,at,rmax)
-  vtot = volsum(nat,at) !--- volume as sum of speherical atoms (crude approximation)
+  vtot = volsum(nat,at) !--- volume as sum of spherical atoms (crude approximation)
 !--- calculate ellipsoid
   roff = sola * vtot / 1000.0d0
   boxr = ((sola * vtot) / pi43)**third + roff + rmax * 0.5

--- a/src/printouts.f90
+++ b/src/printouts.f90
@@ -22,7 +22,7 @@
 !===================================================================================================!
 subroutine confscript_head
       implicit none
-      character(len=40),parameter:: date='Tue 27. Sep 01:07:11 BST 2022'
+      character(len=40),parameter:: date='Mo 30. Jan 18:49:37 GMT 2023'
       character(len=10),parameter:: version='2.12  '
       logical :: niceprint
       


### PR DESCRIPTION
Added the option `-wall`, `-wall-xl`, and `-wall-xxl` to the code at request of @drmewes
These options add a wall potential to the metadynamic simulations, similar to the `-nci` option, but without changing any other settings. the `xl` and `xxl` variants scale the potential axes by a factor of `1.5` and `2.0` respectively. For other sizes the `-wscal` option can be used.