### PR TITLE
track include/

### DIFF
--- a/src/axis_module.f90
+++ b/src/axis_module.f90
@@ -73,8 +73,12 @@ module axis_module
     module procedure CMAxyz
     module procedure CMAv
   end interface cma
+  public :: CMAtrf
 
-contains
+!========================================================================================!
+!========================================================================================!
+contains  !> MODULE PROCEDURES START HERE
+!========================================================================================!
 !========================================================================================!
 !> subroutine axis_0
 !> This is the original axis routine for calculating the

--- a/src/legacy_algos/protonate.f90
+++ b/src/legacy_algos/protonate.f90
@@ -75,6 +75,11 @@ subroutine protonate(env,tim)
   call protclean
   call prothead
 
+!>--- check method
+  if(trim(env%gfnver) .eq. '--gff')then
+     error stop 'protonate unavailable with GFN-FF -> need LMOs'
+  endif
+
   if (.not.allocated(env%ptb%atmap)) allocate (env%ptb%atmap(env%nat))
   if (.not.env%ptb%strictPDT.and..not.env%ptb%fixPDT) then
 !--- sort the input file (H atoms to the bottom)

--- a/src/legacy_algos/tautomerize.f90
+++ b/src/legacy_algos/tautomerize.f90
@@ -62,6 +62,11 @@ subroutine tautomerize(env,tim)
   call tautclean
   call tauthead
 
+!>--- check method
+  if(trim(env%gfnver) .eq. '--gff')then
+     error stop 'tautomerize unavailable with GFN-FF -> need LMOs'
+  endif
+
   if (.not.allocated(env%ptb%atmap)) allocate (env%ptb%atmap(env%nat))
   if (.not.env%ptb%strictPDT.and..not.env%ptb%fixPDT) then
 !--- sort the input file (H atoms to the bottom)


### PR DESCRIPTION
- track `include/` to supress gcc CMake warning
- `-hess` runtype cmd flag (toml keyword did already exist)