### PR TITLE
maintenance fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,14 @@ The program should be directly executable.
 ### Tested builds
 Working and tested builds of CREST (mostly on Ubuntu 20.04 LTS):
 
-| Build System | Compiler | Linear Algebra Backend | Build type     | Status     |
-|--------------|----------|------------------------|:--------------:|:----------:|
-| CMake 3.28.3 | GNU (gcc 10.3.0)  | [OpenBLAS](https://github.com/xianyi/OpenBLAS) (with OpenMP) | dynamic | ✅ |
-| CMake 3.28.3 | GNU (gcc 10.3.0)  |  [MKL shared (oneAPI 2023.1)](https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html) | dynamic | ✅ |
-| CMake 3.28.3 | GNU (gcc 9.5.0)  |  [MKL shared (oneAPI 2023.1)](https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html) | dynamic | ✅ |
-| CMake 3.28.3 | [Intel (`ifort`/`icc` 2021.9.0)](https://www.intel.com/content/www/us/en/developer/tools/oneapi/toolkits.html)   | [MKL static (oneAPI 2023.1)](https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html) | dynamic | ✅ |
-| Meson 1.2.0 | [Intel (`ifort`/`icc` 2021.9.0)](https://www.intel.com/content/www/us/en/developer/tools/oneapi/toolkits.html)   | [MKL static (oneAPI 2023.1)](https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html) | static  | ✅ |
-| Meson 1.2.0 | [Intel (`ifort` 2021.9.0/`icx` 2023.1.0)](https://www.intel.com/content/www/us/en/developer/tools/oneapi/toolkits.html)   | [MKL static (oneAPI 2023.1)](https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html) | static  | ✅ |
+| Build System | Compiler | Linear Algebra Backend | Build type     | Status     | Note |
+|--------------|----------|------------------------|:--------------:|:----------:|:----:|
+| CMake 3.28.3 | GNU (gcc 10.3.0)  | [OpenBLAS](https://github.com/xianyi/OpenBLAS) (with OpenMP) | dynamic | ✅ ||
+| CMake 3.28.3 | GNU (gcc 10.3.0)  |  [MKL shared (oneAPI 2023.1)](https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html) | dynamic | ✅ ||
+| CMake 3.28.3 | GNU (gcc 9.5.0)  |  [MKL shared (oneAPI 2023.1)](https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html) | dynamic | ✅ ||
+| CMake 3.28.3 | [Intel (`ifort`/`icc` 2021.9.0)](https://www.intel.com/content/www/us/en/developer/tools/oneapi/toolkits.html)   | [MKL static (oneAPI 2023.1)](https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html) | dynamic | ⚠️  | OpenMP problem ([#285](https://github.com/crest-lab/crest/issues/285)) |
+| Meson 1.2.0 | [Intel (`ifort`/`icc` 2021.9.0)](https://www.intel.com/content/www/us/en/developer/tools/oneapi/toolkits.html)   | [MKL static (oneAPI 2023.1)](https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html) | static  | ✅ | [continuous release build](https://github.com/crest-lab/crest/releases/tag/latest) |
+| Meson 1.2.0 | [Intel (`ifort` 2021.9.0/`icx` 2023.1.0)](https://www.intel.com/content/www/us/en/developer/tools/oneapi/toolkits.html)   | [MKL static (oneAPI 2023.1)](https://www.intel.com/content/www/us/en/developer/tools/oneapi/onemkl.html) | static  | ✅ ||
 
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,6 +41,7 @@ list(APPEND srcs
   "${dir}/choose_settings.f90"
   "${dir}/classes.f90"
   "${dir}/cleanup.f90"
+  "${dir}/cn.f90"
   "${dir}/compress.f90"
   "${dir}/confparse.f90"
   "${dir}/cregen.f90"

--- a/src/algos/crossing.f90
+++ b/src/algos/crossing.f90
@@ -29,6 +29,7 @@ subroutine crest_crossing(env,maxgen,fname,maxpairs)
   use crest_calculator
   use strucrd
   use optimize_module
+
   implicit none
   !> INPUT
   type(systemdata),intent(inout) :: env
@@ -135,6 +136,7 @@ subroutine crossing(nat,nall,at,xyz,er,ewin,rthr,cthr,maxgen)
   use ls_rmsd
   use strucrd
   use miscdata, only: rcov
+  use crest_cn_module
   implicit none
   !> INPUT
   integer,intent(in)  :: nat,nall           !> number of atoms, number of structures
@@ -187,7 +189,7 @@ subroutine crossing(nat,nall,at,xyz,er,ewin,rthr,cthr,maxgen)
 
   !>--- lowest conformer to provide reference values
   xyzref(1:3,1:nat) = xyz(1:3,1:nat,minpos)  !> reference Cartesians
-  call ycoord(nat,rcov,at,xyzref,cnref,100.0d0) !> refernce CNs
+  call cn_ycoord(nat,rcov,at,xyzref,cnref,100.0d0) !> refernce CNs
   call XYZINT(xyzref,nat,na,nb,nc,1.0d0,zdum)   !> z-mat connectivity
   zref(:,:) = real(zdum,sp)                    !> reference z-mat
 
@@ -251,7 +253,7 @@ subroutine crossing(nat,nall,at,xyz,er,ewin,rthr,cthr,maxgen)
         ierr = ierr+1
         cycle
       end if
-      call ycoord2(nat,rcov,at,cdum,cnref,100.d0,cthr,fail) !> CN clashes
+      call cn_ycoord2(nat,rcov,at,cdum,cnref,100.d0,cthr,fail) !> CN clashes
       if (fail) then
         !$omp atomic
         ierr = ierr+1

--- a/src/algos/hessian_tools.f90
+++ b/src/algos/hessian_tools.f90
@@ -353,7 +353,7 @@ contains  !> MODULE PROCEDURES START HERE
     if (lb .eq. nat) go to 90
     go to 70
 90  if (kb .eq. k) then
-      return
+      goto 200
     end if
 
     ka = kc+1
@@ -364,7 +364,7 @@ contains  !> MODULE PROCEDURES START HERE
 105 format(3x,3(18x,a5))
 110 format(a15,f11.4,12x,f11.4,12x,f11.4)
 130 format(2i4,3(2x,3f7.2))
-
+200 continue
     write (gu,'(''end of file'')')
     close (gu)
 

--- a/src/algos/optimization.f90
+++ b/src/algos/optimization.f90
@@ -70,19 +70,25 @@ subroutine crest_optimization(env,tim)
 !>-- geometry optimization
   pr = .true. !> stdout printout
   wr = .true. !> write crestopt.log
+!>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<!
+!>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<!
   call optimize_geometry(mol,molnew,calc,energy,grad,pr,wr,io)
-
+!>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<!
+!>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<!
   if (io == 0) then
+!>--- print out the results
+    write (stdout,*) 'SUCCESS!'
     write (stdout,*) 'geometry successfully optimized!'
     write (stdout,*)
     write(stdout,'(a)') repeat('-',80)
 
     write (stdout,*)
-    call smallhead( 'Output structure:') 
-    call molnew%append(stdout)
-    write (stdout,*)
+    write (stdout,'(1x,a)') 'FINAL CALCULATION SUMMARY'
+    write (stdout,'(1x,a)') '========================='
+    call calculation_summary(calc,mol,energy,grad,molnew)
 
-    write (stdout,*) 'optimized geometry written to crestopt.xyz'
+    write (stdout,*)
+    write (stdout,'(a)') '> Optimized geometry written to crestopt.xyz'
     gnorm = norm2(grad)
     write (atmp,'(1x,"Etot=",f16.10,1x,"g norm=",f12.8)') energy,gnorm
     molnew%comment = trim(atmp)
@@ -90,58 +96,16 @@ subroutine crest_optimization(env,tim)
     open (newunit=ich,file='crestopt.xyz')
     call molnew%append(ich)
     close (ich)
-
   else
     write (stdout,*) 'geometry optimization FAILED!'
+  endif
 
-  end if
+  write (stdout,*)
+  write (stdout,'(a)') repeat('=',42)
+  write (stdout,'(1x,a,f20.10,a)') 'TOTAL ENERGY   ',energy,' Eh'
+  write (stdout,'(1x,a,f20.10,a)') 'GRADIENT NORM  ',norm2(grad),' Eh/a0'
+  write (stdout,'(a)') repeat('=',42)
 
-!========================================================================================!
-!>--- print out the results
-   if(any(calc%calcs(:)%rdwbo))then
-   write(stdout,*)
-   write(stdout,*) 'Connectivity information (bond order):'
-   do k=1,calc%ncalculations
-     if(calc%calcs(k)%rdwbo)then
-       write(stdout,'("> ",a,i0)') 'Calculation level ',k
-       write(stdout,'(a12,a12,a10)') 'Atom A','Atom B','BO(A-B)'
-       do i=1,mol%nat
-         do j=1,i-1
-           if(calc%calcs(k)%wbo(i,j) > 0.0002_wp)then
-            write(stdout,*) i,j,calc%calcs(k)%wbo(i,j)
-           endif
-         enddo
-       enddo
-     endif
-   enddo
-   endif
-   write(stdout,*)
-
-   write(stdout,'(a)') repeat('-',80)
-   write(stdout,'(a)') '> Final molecular gradient ( Eh/a0 ):'
-   write(stdout,'(13x,a,13x,a,13x,a)')partial//'x',partial//'y',partial//'z'
-   do i = 1,mol%nat
-      write (stdout,'(3f18.8)') grad(1:3,i)
-   end do
-   write(stdout,'(a,f18.8,a)') '> Gradient norm:',norm2(grad),' Eh/a0'
-
-   if(calc%ncalculations > 1)then
-   write(stdout,*)
-   write(stdout,'(a)') '> Individual energies and gradient norms:'
-     do k=1,calc%ncalculations
-       write(stdout,'(1x,a,i3,2f18.8)') 'calculation ',k,calc%etmp(k),norm2(calc%grdtmp(:,:,k))
-     enddo
-     if(calc%nconstraints > 0)then
-       write(stdout,'(1x,a)') '(+ constraints contribution)'
-     endif
-   endif
-
-   write(stdout,*)
-   write(stdout,'(a)') repeat('=',40)
-   write(stdout,'(1x,a,f20.10,a)') 'TOTAL ENERGY ',energy,' Eh'
-   write(stdout,'(1x,a,f20.10,a)') 'GRADIENT NORM',norm2(grad),' Eh/a0'
-   write(stdout,'(a)') repeat('=',40)
-   
    if(io /= 0)then
     write (stdout,*) 'WARNING: geometry optimization FAILED!'
    endif

--- a/src/algos/parallel.f90
+++ b/src/algos/parallel.f90
@@ -495,8 +495,10 @@ subroutine crest_search_multimd(env,mol,mddats,nsim)
 
   !>--- run the MDs
   !$omp parallel &
-  !$omp shared(env,calculations,mddats,mol,pr,percent,ich, moltmps, nested,Tn)
-  !$omp single
+  !$omp shared(env,calculations,mddats,mol,pr,percent,ich, nsim, moltmps, nested,Tn) &
+  !!$omp single
+  !$omp private(vz,i,job,thread_id,io,ex)
+  !$omp do
   do i = 1,nsim
 
     call initsignal()
@@ -505,7 +507,7 @@ subroutine crest_search_multimd(env,mol,mddats,nsim)
     !>--- OpenMP nested region threads
     if(nested) call ompmklset(Tn)
 
-    !$omp task firstprivate( vz ) private( job,thread_id,io,ex )
+    !!$omp task firstprivate( vz ) private( job,thread_id,io,ex )
     call initsignal()
 
     thread_id = OMP_GET_THREAD_NUM()
@@ -525,10 +527,9 @@ subroutine crest_search_multimd(env,mol,mddats,nsim)
 
     !>--- finish printout (thread safe)
     call parallel_md_finish_printout(mddats(vz),vz,io,profiler)
-    !$omp end task
+    !!$omp end task
   end do
-  !$omp taskwait
-  !$omp end single
+  !!$omp taskwait
   !$omp end parallel
 
   !>--- collect trajectories into one

--- a/src/algos/refine.f90
+++ b/src/algos/refine.f90
@@ -36,7 +36,7 @@ subroutine crest_refine(env,input,output)
   character(len=*),intent(in) :: input
   character(len=*),intent(in),optional :: output
 !===========================================================!
-  integer :: i,j,k,l,io,ich,m
+  integer :: i,j,k,l,io,ich,m,t1,t2
   logical :: pr,wr,ex
 !===========================================================!
   character(len=:),allocatable :: outname
@@ -98,8 +98,9 @@ subroutine crest_refine(env,input,output)
         call crest_oloop(env,nat,nall,at,xyz,eread,.false.)
 
       case(refine%confsolv)
+        call new_ompautoset(env,'subprocess',1,t1,t2)
         write (stdout,'("> ConfSolv: ΔΔGsoln estimation from 3D directed message passing neural networks (D-MPNN)")')
-        call confsolv_request( input, nall, env%threads, etmp, io)
+        call confsolv_request( input, nall, t2, etmp, io)
         if(io == 0)then
         eread(:) = etmp(:)*kcaltoau  !> since CREGEN deals with Eh energies
         endif   

--- a/src/algos/singlepoint.f90
+++ b/src/algos/singlepoint.f90
@@ -85,7 +85,11 @@ subroutine crest_singlepoint(env,tim)
   write (stdout,'(a)') repeat('-',80)
   write (stdout,'(a)',advance='no') '> Performing singlepoint calculations ... '
   flush (stdout)
+!>>>>>>>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<<<!
+!>>>>>>>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<<<!
   call engrad(mol,calc,energy,grad,io)
+!>>>>>>>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<<<!
+!>>>>>>>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<<<!
   call tim%stop(14)
   write (stdout,*) 'done.'
   write (atmp,'(a)') '> Total wall time for calculations'
@@ -94,79 +98,20 @@ subroutine crest_singlepoint(env,tim)
   if (io /= 0) then
     write (stdout,*)
     write (stdout,*) 'WARNING: Calculation exited with error!'
-    return
-  end if
-
+  else
 !>--- print out the results
-  if (any(calc%calcs(:)%rdwbo)) then
+    write (stdout,*) 'SUCCESS!'
     write (stdout,*)
-    write (stdout,*) 'Connectivity information (bond order):'
-    do k = 1,calc%ncalculations
-      if (calc%calcs(k)%rdwbo) then
-        write (stdout,'("> ",a,i0)') 'Calculation level ',k
-        write (stdout,'(a12,a12,a10)') 'Atom A','Atom B','BO(A-B)'
-        do i = 1,mol%nat
-          do j = 1,i-1
-            if (calc%calcs(k)%wbo(i,j) > 0.01_wp) then
-              write (stdout,*) i,j,calc%calcs(k)%wbo(i,j)
-            end if
-          end do
-        end do
-      end if
-    end do
-    write (stdout,*)
-    write (stdout,'(a)') repeat('-',80)
-  else
-    write (stdout,*)
-  end if
-
-  if (any(calc%calcs(:)%rddip)) then
-    write (stdout,*)
-    write (stdout,*) 'Molecular dipole moments (a.u.):'
-    do k = 1,calc%ncalculations
-      if (calc%calcs(k)%rddip) then
-        dip = norm2(calc%calcs(k)%dipole)
-        write (stdout,'("> ",a,i0)') 'Calculation level ',k
-        write (stdout,'(a10,a10,a10,a12)') 'x','y','z','tot (Debye)'
-        write (stdout,'(4f10.3)') calc%calcs(k)%dipole(:),dip*autod
-      end if
-    end do
-    write (stdout,*)
-    write (stdout,'(a)') repeat('-',80)
-  else
-    write (stdout,*)
-  end if
-
-  if (all(calc%calcs(:)%rdgrad.eqv..false.)) then
-    write (stdout,'(a)') '> No gradients calculated'
-  else
-    write (stdout,'(a)') '> Final molecular gradient ( Eh/a0 ):'
-    write (stdout,'(13x,a,13x,a,13x,a)') partial//'x',partial//'y',partial//'z'
-    do i = 1,mol%nat
-      write (stdout,'(3f18.8)') grad(1:3,i)
-    end do
-    write (stdout,'(a,f18.8,a)') '> Gradient norm:',norm2(grad),' Eh/a0'
-  end if
-
-  if (calc%ncalculations > 1) then
-    write (stdout,*)
-    write (stdout,'(a)') '> Individual energies and gradient norms:'
-    do k = 1,calc%ncalculations
-      write (stdout,'(1x,a,i3,2f18.8)') 'calculation ',k,calc%etmp(k),norm2(calc%grdtmp(:,:,k))
-    end do
-    if (calc%nconstraints > 0) then
-      write (stdout,'(1x,a)') '(+ constraints contribution)'
-    end if
+    write (stdout,'(1x,a)') 'SINGLEPOINT SUMMARY'
+    write (stdout,'(1x,a)') '==================='
+    call calculation_summary(calc,mol,energy,grad)
   end if
 
   write (stdout,*)
-  write (stdout,'(a)') repeat('=',40)
-  write (stdout,'(1x,a,f20.10,a)') 'TOTAL ENERGY ',energy,' Eh'
-  write (stdout,'(1x,a,f20.10,a)') 'GRADIENT NORM',norm2(grad),' Eh/a0'
-  write (stdout,'(a)') repeat('=',40)
-
-  write (stdout,'(1x,a)') 'Writing crest.engrad ...'
-  call write_engrad('crest.engrad',energy,grad)
+  write (stdout,'(a)') repeat('=',42)
+  write (stdout,'(1x,a,f20.10,a)') 'TOTAL ENERGY   ',energy,' Eh'
+  write (stdout,'(1x,a,f20.10,a)') 'GRADIENT NORM  ',norm2(grad),' Eh/a0'
+  write (stdout,'(a)') repeat('=',42)
 
   if (env%testnumgrad) then
     call numgrad(mol,calc,grad)
@@ -208,7 +153,7 @@ subroutine crest_xtbsp(env,xtblevel,molin)
   real(wp) :: energy
   real(wp),allocatable :: grad(:,:)
 
-  !>--- transfer settings from env to tmpcalc
+!>--- transfer settings from env to tmpcalc
   call env2calc(env,tmpcalc,molin)
 
   tmpcalc%calcs(1)%rdwbo = .true. !> obtain WBOs
@@ -230,16 +175,18 @@ subroutine crest_xtbsp(env,xtblevel,molin)
     call mol%open('coord')
   end if
   allocate (grad(3,mol%nat),source=0.0_wp)
-
+!>>>>>>>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<<<!
+!>>>>>>>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<<<!
   call engrad(mol,tmpcalc,energy,grad,io)
+!>>>>>>>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<<<!
+!>>>>>>>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<<<<!
   if (io .ne. 0) then
     error stop 'crest_xtbsp failed'
   end if
 
-  !>--- write wbo file
+!>--- write wbo file
   if (tmpcalc%calcs(1)%rdwbo) then
     call write_wbo(tmpcalc%calcs(1)%wbo,0.002_wp)
-
   end if
 
   deallocate (grad)

--- a/src/axis_module.f90
+++ b/src/axis_module.f90
@@ -336,7 +336,7 @@ contains  !> MODULE PROCEDURES START HERE
     allocate (attmp(nat0))
     allocate (coordtmp(3,nat0))
     attmp(1:nat0) = at(1:nat0)
-    coordtmp(3,1:nat0) = coord(3,1:nat0)
+    coordtmp(1:3,1:nat0) = coord(1:3,1:nat0)
     call axis_0(nat0,attmp,coordtmp,rot,avmom,evec)
     deallocate (coordtmp,attmp)
 

--- a/src/calculator/CMakeLists.txt
+++ b/src/calculator/CMakeLists.txt
@@ -19,6 +19,7 @@ set(dir "${CMAKE_CURRENT_SOURCE_DIR}")
 list(APPEND srcs
   "${dir}/calculator.F90"
   "${dir}/calc_type.f90"
+  "${dir}/printouts.F90"
   "${dir}/constraints.f90"
   "${dir}/gfn0_api.F90"
   "${dir}/gfnff_api.F90"

--- a/src/calculator/api_engrad.f90
+++ b/src/calculator/api_engrad.f90
@@ -34,6 +34,7 @@ module api_engrad
   use gfn0_api
   use gfnff_api
   use xhcff_api
+  use lj
   implicit none
 !>--- private module variables and parameters
   private
@@ -42,6 +43,7 @@ module api_engrad
   public :: gfn0_engrad,gfn0occ_engrad
   public :: gfnff_engrad
   public :: xhcff_engrad
+  public :: lj_engrad !> RE-EXPORT
 
 !=========================================================================================!
 !=========================================================================================!

--- a/src/calculator/api_helpers.F90
+++ b/src/calculator/api_helpers.F90
@@ -354,6 +354,9 @@ contains    !> MODULE PROCEDURES START HERE
        & allocate (calc%qat(mol%nat), source=0.0_wp)
        calc%qat = calc%ff_dat%nlist%q
    endif
+   if(allocated(calc%getsasa))then
+     call gfnff_dump_sasa(calc%ff_dat,mol%nat,calc%getsasa)
+   endif
 #endif
   end subroutine gfnff_properties
 

--- a/src/calculator/api_helpers.F90
+++ b/src/calculator/api_helpers.F90
@@ -241,6 +241,11 @@ contains    !> MODULE PROCEDURES START HERE
     if (calc%rddip) then
       call gfn0_getdipole(g0calc,mol,calc%dipole)
     end if
+    if (calc%rdqat)then
+       if(.not.allocated(calc%qat)) &
+       & allocate (calc%qat(mol%nat), source=0.0_wp)
+       call gfn0_getqat(g0calc,mol,calc%qat) 
+    endif
 #endif
   end subroutine gfn0_properties
 
@@ -344,6 +349,11 @@ contains    !> MODULE PROCEDURES START HERE
     if (calc%rddip) then
       calc%dipole = matmul(calc%ff_dat%nlist%q,transpose(mol%xyz))
     end if
+   if (calc%rdqat)then
+       if(.not.allocated(calc%qat)) &
+       & allocate (calc%qat(mol%nat), source=0.0_wp)
+       calc%qat = calc%ff_dat%nlist%q
+   endif
 #endif
   end subroutine gfnff_properties
 

--- a/src/calculator/calc_type.f90
+++ b/src/calculator/calc_type.f90
@@ -75,7 +75,7 @@ module calc_type
     integer :: id = 0         !> calculation type (see "jobtype" parameter above)
     integer :: prch = stdout  !> printout channel
     logical :: pr = .false.   !> allow the calculation to produce printout? Results in a lot I/O
-    logical :: prappend = .false. !> append printout 
+    logical :: prappend = .false. !> append printout
     integer :: refine_lvl = 0 !> to allow defining different refinement levels
 
     integer :: chrg = 0          !> molecular charge
@@ -111,7 +111,7 @@ module calc_type
     !> atomic charges
     logical :: rdqat = .false.
     real(wp),allocatable :: qat(:)
-    
+
     !> dipole and dipole gradient
     logical :: rddip = .false.
     real(wp) :: dipole(3) = 0.0_wp
@@ -153,7 +153,7 @@ module calc_type
     type(xhcff_calculator),allocatable :: xhcff
 
     !> ONIOM fragment IDs
-    integer :: ONIOM_highlowroot = 0 
+    integer :: ONIOM_highlowroot = 0
     integer :: ONIOM_id = 0
 
     !> ORCA job template
@@ -236,7 +236,7 @@ module calc_type
     logical :: pr_energies = .false.
     integer :: eout_unit = stdout
     character(len=:),allocatable :: elog
-    
+
 !>--- ONIOM calculator data
     type(lwoniom_data),allocatable :: ONIOM
     type(coord),allocatable :: ONIOMmols(:)
@@ -260,6 +260,8 @@ module calc_type
     procedure :: active_restore => calc_set_active_restore
     procedure :: freezegrad => calculation_freezegrad
   end type calcdata
+
+  public :: get_dipoles
 
 !========================================================================================!
 !========================================================================================!
@@ -331,11 +333,7 @@ contains  !>--- Module routines start here
     if (allocated(self%efile)) deallocate (self%efile)
     if (allocated(self%solvmodel)) deallocate (self%solvmodel)
     if (allocated(self%solvent)) deallocate (self%solvent)
-    !if (allocated(self%wfn)) deallocate (self%wfn)
-    !if (allocated(self%tbcalc)) deallocate (self%tbcalc)
-    !if (allocated(self%ctx)) deallocate (self%ctx)
-    !if (allocated(self%tbres)) deallocate (self%tbres)
-    if (allocated(self%tblite)) deallocate(self%tblite)
+    if (allocated(self%tblite)) deallocate (self%tblite)
     if (allocated(self%g0calc)) deallocate (self%g0calc)
     if (allocated(self%ff_dat)) deallocate (self%ff_dat)
     if (allocated(self%xhcff)) deallocate (self%xhcff)
@@ -447,7 +445,6 @@ contains  !>--- Module routines start here
 
     return
   end subroutine calculation_add_constraintlist
-
 
 !=========================================================================================!
 
@@ -590,16 +587,15 @@ contains  !>--- Module routines start here
     real(wp),intent(inout) :: grad(:,:)
     integer :: nat,i
     if (self%nfreeze > 0) then
-       nat = size(grad,2)
-       if(nat == self%nfreeze)then
-         error stop '*** ERROR *** Must not freeze all atoms!'
-       endif 
-       do i =1,nat
-         if(self%freezelist(i)) grad(:,i) = 0.0_wp
-       enddo
+      nat = size(grad,2)
+      if (nat == self%nfreeze) then
+        error stop '*** ERROR *** Must not freeze all atoms!'
+      end if
+      do i = 1,nat
+        if (self%freezelist(i)) grad(:,i) = 0.0_wp
+      end do
     end if
   end subroutine calculation_freezegrad
-
 
 !=========================================================================================!
 
@@ -627,9 +623,8 @@ contains  !>--- Module routines start here
     class(calculation_settings) :: self
     self%restart = .false.
     if (allocated(self%refgeo)) deallocate (self%refgeo)
-    if (allocated(self%restartfile)) deallocate(self%restartfile)
+    if (allocated(self%restartfile)) deallocate (self%restartfile)
   end subroutine calculation_settings_norestarts
-
 
 !=========================================================================================!
 
@@ -668,20 +663,18 @@ contains  !>--- Module routines start here
     self%prch = dum
   end subroutine calculation_settings_printid
 
-
   subroutine calculation_dump_dipgrad(self,filename)
     implicit none
     class(calculation_settings) :: self
     character(len=*),intent(in) :: filename
     integer :: i,j,ich
-    if(.not.allocated(self%dipgrad)) return 
-    open(newunit=ich,file=filename)
-    do i=1,size(self%dipgrad,2)
-      write(ich,'(3f20.10)') self%dipgrad(1:3,i)
-    enddo 
-    close(ich)
+    if (.not.allocated(self%dipgrad)) return
+    open (newunit=ich,file=filename)
+    do i = 1,size(self%dipgrad,2)
+      write (ich,'(3f20.10)') self%dipgrad(1:3,i)
+    end do
+    close (ich)
   end subroutine calculation_dump_dipgrad
-
 
 !=========================================================================================!
 
@@ -705,11 +698,11 @@ contains  !>--- Module routines start here
       error stop
     end if
 
-    write(stdout,'(a)',advance='no') 'Assigning and duplicating calculators for ONIOM setup ...'
-    flush(stdout)
+    write (stdout,'(a)',advance='no') 'Assigning and duplicating calculators for ONIOM setup ...'
+    flush (stdout)
 
     allocate (self%ONIOMmap(ncalcs),source=0)
-    allocate (newids(2,self%ONIOM%nfrag), source = 0)
+    allocate (newids(2,self%ONIOM%nfrag),source=0)
     k = 0
     do i = 1,self%ONIOM%nfrag
 
@@ -719,13 +712,13 @@ contains  !>--- Module routines start here
         if (l == 2) then
           !> to exlcude the highest ONIOM layer, we need to cycle
           j2 = self%ONIOM%calcids(1,i)
-          if (j == j2)then
-             newid = newids(1,i)
-             newids(2,i) = newid
-             self%calcs(newid)%ONIOM_highlowroot = 3
-             self%calcs(newid)%ONIOM_id = i
-             cycle
-          endif
+          if (j == j2) then
+            newid = newids(1,i)
+            newids(2,i) = newid
+            self%calcs(newid)%ONIOM_highlowroot = 3
+            self%calcs(newid)%ONIOM_id = i
+            cycle
+          end if
         end if
 
         if (any(self%ONIOMmap(:) .eq. j)) then
@@ -748,13 +741,13 @@ contains  !>--- Module routines start here
 
         self%calcs(newid)%ONIOM_highlowroot = l
         self%calcs(newid)%ONIOM_id = i
-        select case(l)
-        case( 1 ) 
-        write(atmp,'(a,i0,a)') 'ONIOM.',i,'.high'
-        case( 2 )
-        write(atmp,'(a,i0,a)') 'ONIOM.',i,'.low'
-        case( 3 )
-        write(atmp,'(a,i0,a)') 'ONIOM.',i,'.root'
+        select case (l)
+        case (1)
+          write (atmp,'(a,i0,a)') 'ONIOM.',i,'.high'
+        case (2)
+          write (atmp,'(a,i0,a)') 'ONIOM.',i,'.low'
+        case (3)
+          write (atmp,'(a,i0,a)') 'ONIOM.',i,'.root'
         end select
         self%calcs(newid)%calcspace = trim(atmp)
 
@@ -762,26 +755,26 @@ contains  !>--- Module routines start here
         self%calcs(newid)%weight = 0.0_wp
 
         !> Check if the ONIOM fragment has a charge attached!
-        if(allocated(self%ONIOM%fragment(i)%chrg))then
+        if (allocated(self%ONIOM%fragment(i)%chrg)) then
           self%calcs(newid)%chrg = self%ONIOM%fragment(i)%chrg
-        endif 
+        end if
 
       end do
     end do
     self%ONIOM%calcids = newids
-    deallocate(newids)
+    deallocate (newids)
 
-    if(allocated(self%ONIOMrevmap)) deallocate(self%ONIOMrevmap)
-    allocate(self%ONIOMrevmap( self%ncalculations ), source=0)
-    do i =1,self%ncalculations
-       do j =1,self%ONIOM%ncalcs
-         if( self%ONIOMmap(j) == i)then
-            self%ONIOMrevmap(i) = j
-         endif
-       enddo
-    enddo
+    if (allocated(self%ONIOMrevmap)) deallocate (self%ONIOMrevmap)
+    allocate (self%ONIOMrevmap(self%ncalculations),source=0)
+    do i = 1,self%ncalculations
+      do j = 1,self%ONIOM%ncalcs
+        if (self%ONIOMmap(j) == i) then
+          self%ONIOMrevmap(i) = j
+        end if
+      end do
+    end do
 
-    write(stdout,*) 'done.'
+    write (stdout,*) 'done.'
   end subroutine calculation_ONIOMexpand
 
 !=========================================================================================!
@@ -856,21 +849,20 @@ contains  !>--- Module routines start here
     write (atmp,*) 'Read dipoles?'
     if (self%rddip) write (iunit,fmt3) atmp,'yes'
 
-
-    if(self%ONIOM_highlowroot /= 0)then
-      select case(self%ONIOM_highlowroot)
-      case( 1 )
-      write (atmp,*) 'ONIOM frag ("high")'
-      case(2)
-      write (atmp,*) 'ONIOM frag ("low")'
-      case(3)
-      write (atmp,*) 'ONIOM frag ("root")'
+    if (self%ONIOM_highlowroot /= 0) then
+      select case (self%ONIOM_highlowroot)
+      case (1)
+        write (atmp,*) 'ONIOM frag ("high")'
+      case (2)
+        write (atmp,*) 'ONIOM frag ("low")'
+      case (3)
+        write (atmp,*) 'ONIOM frag ("root")'
       end select
       write (iunit,fmt1) trim(atmp),self%ONIOM_id
     else
       write (atmp,*) 'Weight'
       write (iunit,fmt2) atmp,self%weight
-    endif
+    end if
 
   end subroutine calculation_settings_info
 
@@ -893,11 +885,11 @@ contains  !>--- Module routines start here
       write (iunit,'("> ",a)') 'No calculation levels set up!'
     else if (self%ncalculations > 1) then
       do i = 1,self%ncalculations
-        if(self%calcs(i)%ONIOM_id > 0 )then
-        write (iunit,'("> ",a,i0,a)') 'Automatic ONIOM setup calculation level ',i,':'
+        if (self%calcs(i)%ONIOM_id > 0) then
+          write (iunit,'("> ",a,i0,a)') 'Automatic ONIOM setup calculation level ',i,':'
         else
-        write (iunit,'("> ",a,i0,a)') 'User-defined calculation level ',i,':'
-        endif
+          write (iunit,'("> ",a,i0,a)') 'User-defined calculation level ',i,':'
+        end if
         call self%calcs(i)%info(iunit)
       end do
     else
@@ -908,25 +900,25 @@ contains  !>--- Module routines start here
 
     if (self%nconstraints > 0) then
       write (iunit,'("> ",a)') 'User-defined constraints:'
-      if(self%nconstraints <= 20)then
+      if (self%nconstraints <= 20) then
         do i = 1,self%nconstraints
           call self%cons(i)%print(iunit)
         end do
       else
-         constraintype(:) = 0
-         do i = 1,self%nconstraints
+        constraintype(:) = 0
+        do i = 1,self%nconstraints
           j = self%cons(i)%type
-          if(j > 0 .and. j < 9)then
-            constraintype(j) = constraintype(j) + 1
-          endif 
-         end do
-         if(constraintype(1) > 0) write (iunit,'(2x,a,i0)') '# bond constraints    : ',constraintype(1)
-         if(constraintype(2) > 0) write (iunit,'(2x,a,i0)') '# angle constraints   : ',constraintype(2)
-         if(constraintype(3) > 0) write (iunit,'(2x,a,i0)') '# dihedral constraints: ',constraintype(3)
-         if(constraintype(4) > 0) write (iunit,'(2x,a,i0)') '# wall potential      : ',constraintype(4)
-         if(constraintype(5) > 0) write (iunit,'(2x,a,i0)') '# wall(logfermi) potential  : ',constraintype(5)
-         if(constraintype(8) > 0) write (iunit,'(2x,a,i0)') '# bondrange constraints    : ',constraintype(8)
-      endif 
+          if (j > 0.and.j < 9) then
+            constraintype(j) = constraintype(j)+1
+          end if
+        end do
+        if (constraintype(1) > 0) write (iunit,'(2x,a,i0)') '# bond constraints    : ',constraintype(1)
+        if (constraintype(2) > 0) write (iunit,'(2x,a,i0)') '# angle constraints   : ',constraintype(2)
+        if (constraintype(3) > 0) write (iunit,'(2x,a,i0)') '# dihedral constraints: ',constraintype(3)
+        if (constraintype(4) > 0) write (iunit,'(2x,a,i0)') '# wall potential      : ',constraintype(4)
+        if (constraintype(5) > 0) write (iunit,'(2x,a,i0)') '# wall(logfermi) potential  : ',constraintype(5)
+        if (constraintype(8) > 0) write (iunit,'(2x,a,i0)') '# bondrange constraints    : ',constraintype(8)
+      end if
       write (iunit,*)
     end if
 
@@ -943,15 +935,15 @@ contains  !>--- Module routines start here
         write (iunit,'(1x,a)') 'Energies and gradients of all calculation levels will be'// &
         & ' added according to their weights'
       end select
-      if(allocated(self%ONIOM))then
+      if (allocated(self%ONIOM)) then
         write (iunit,'(1x,a)') 'ONIOM energy and gradient will be constructed from calculations:'
-        do i=1,self%ncalculations
-          if(any(self%ONIOMmap(:).eq.i))then
-             write(stdout,'(1x,i0)',advance='no') i
-          endif
-        enddo
+        do i = 1,self%ncalculations
+          if (any(self%ONIOMmap(:) .eq. i)) then
+            write (stdout,'(1x,i0)',advance='no') i
+          end if
+        end do
         write (iunit,*)
-      endif
+      end if
       write (iunit,*)
     end if
 
@@ -998,42 +990,63 @@ contains  !>--- Module routines start here
 !=========================================================================================!
 
   subroutine calc_set_active(self,ids)
-     implicit none
-     class(calcdata) :: self
-     integer,intent(in) :: ids(:) 
-     integer :: i,j,k,l
-     if(allocated(self%weightbackup)) deallocate(self%weightbackup)
+    implicit none
+    class(calcdata) :: self
+    integer,intent(in) :: ids(:)
+    integer :: i,j,k,l
+    if (allocated(self%weightbackup)) deallocate (self%weightbackup)
 !>--- on-the-fly multiscale definition
-      allocate(self%weightbackup(self%ncalculations), source = 1.0_wp)
-      do i=1,self%ncalculations
+    allocate (self%weightbackup(self%ncalculations),source=1.0_wp)
+    do i = 1,self%ncalculations
 !>--- save backup weights
-        self%weightbackup(i) =  self%calcs(i)%weight
+      self%weightbackup(i) = self%calcs(i)%weight
 !>--- set the weight of all unwanted calculations to 0
-        if(.not.any(ids(:).eq.i))then
-           self%calcs(i)%weight = 0.0_wp
-           self%calcs(i)%active = .false.
-        else
+      if (.not.any(ids(:) .eq. i)) then
+        self%calcs(i)%weight = 0.0_wp
+        self%calcs(i)%active = .false.
+      else
 !>--- and all other to 1
-           self%calcs(i)%weight = 1.0_wp
-           self%calcs(i)%active = .true.
-        endif
-      enddo
-  end subroutine calc_set_active
-  
-  subroutine calc_set_active_restore(self)
-     implicit none
-     class(calcdata) :: self
-     integer :: i,j,k,l
-     if(.not.allocated(self%weightbackup)) return
-     do i=1,self%ncalculations
-!>--- set all to active and restore saved weights        
-        self%calcs(i)%weight = self%weightbackup(i)
+        self%calcs(i)%weight = 1.0_wp
         self%calcs(i)%active = .true.
-        self%eweight(i) = self%weightbackup(i)
-     enddo
-     deallocate(self%weightbackup)
-  end subroutine calc_set_active_restore
- 
+      end if
+    end do
+  end subroutine calc_set_active
 
+  subroutine calc_set_active_restore(self)
+    implicit none
+    class(calcdata) :: self
+    integer :: i,j,k,l
+    if (.not.allocated(self%weightbackup)) return
+    do i = 1,self%ncalculations
+!>--- set all to active and restore saved weights
+      self%calcs(i)%weight = self%weightbackup(i)
+      self%calcs(i)%active = .true.
+      self%eweight(i) = self%weightbackup(i)
+    end do
+    deallocate (self%weightbackup)
+  end subroutine calc_set_active_restore
+
+!==========================================================================================!
+
+  subroutine get_dipoles(calc,diptmp)
+!*********************************************
+!* Collect the x y and z dipole moments for
+!* each calculation level in one array diptmp
+!*********************************************
+    implicit none
+    type(calcdata),intent(inout) :: calc
+    real(wp),allocatable,intent(out) :: diptmp(:,:)
+    integer :: i,j,k,l,m
+
+    m = calc%ncalculations
+    allocate (diptmp(3,m),source=0.0_wp)
+    do i = 1,m
+      if (calc%calcs(i)%rddip) then
+        diptmp(1:3,i) = calc%calcs(i)%dipole(1:3)
+      end if
+    end do
+  end subroutine get_dipoles
+
+!=========================================================================================!
 !=========================================================================================!
 end module calc_type

--- a/src/calculator/calc_type.f90
+++ b/src/calculator/calc_type.f90
@@ -91,6 +91,7 @@ module calc_type
     character(len=:),allocatable :: binary      !> binary or generic script
     character(len=:),allocatable :: systemcall  !> systemcall for running generic scripts
     character(len=:),allocatable :: description !> see above jobdescription parameter
+    character(len=:),allocatable :: shortflag   !> shorter job description
 
 !>--- gradient format specifications
     logical :: rdgrad = .true.
@@ -638,6 +639,7 @@ contains  !>--- Module routines start here
 
     !> add a short description
     self%description = trim(jobdescription(self%id+1))
+    call calculation_settings_shortflag(self)
 
     if (.not.allocated(self%calcspace)) then
       !> I've decided to perform all calculations in a separate directory to
@@ -650,6 +652,58 @@ contains  !>--- Module routines start here
       self%prch = self%prch+id
     end if
   end subroutine calculation_settings_autocomplete
+
+!>--- create a short calculation info flag
+    subroutine calculation_settings_shortflag(self)
+    implicit none
+    class(calculation_settings) :: self
+    integer :: i,j
+
+    select case( self%id )
+    case( jobtype%xtbsys )   
+      self%shortflag = 'xtb subprocess'
+    case( jobtype%generic ) 
+      self%shortflag = 'generic subprocess' 
+    case( jobtype%turbomole ) 
+      self%shortflag = 'TURBOMOLE subprocess'
+    case( jobtype%orca ) 
+      self%shortflag = 'ORCA subprocess'
+    case( jobtype%terachem ) 
+      self%shortflag = 'TeraChem subprocess'
+    case( jobtype%tblite )
+      select case (self%tblitelvl)
+      case (xtblvl%gfn2)
+        self%shortflag = 'GFN2-xTB'
+      case (xtblvl%gfn1)
+        self%shortflag = 'GFN1-xTB'
+      case (xtblvl%ipea1)
+        self%shortflag = 'IPEA1-xTB'
+      case (xtblvl%ceh)
+        self%shortflag = 'CEH'
+      case (xtblvl%eeq)
+        self%shortflag = 'EEQ(D4)'
+      end select
+    case( jobtype%gfn0 )
+      self%shortflag =  'GFN0-xTB' 
+    case( jobtype%gfn0occ )
+      self%shortflag =  'GFN0-xTB*'
+    case( jobtype%gfnff )
+      self%shortflag =  'GFN-FF'
+    case( jobtype%xhcff )
+      self%shortflag =  'XHCFF'
+    case( jobtype%lj )
+      self%shortflag =  'LJ'
+    case default
+      self%shortflag = 'undefined'
+    end select
+    if(allocated(self%solvmodel).and.allocated(self%solvent))then
+      self%shortflag = self%shortflag//'/'//trim(self%solvmodel)
+       self%shortflag = self%shortflag//'('//trim(self%solvent)//')'
+    endif
+  end subroutine calculation_settings_shortflag
+
+
+
 
 !>-- generate a unique print id for the calculation
   subroutine calculation_settings_printid(self,thread,id)

--- a/src/calculator/calc_type.f90
+++ b/src/calculator/calc_type.f90
@@ -119,6 +119,9 @@ module calc_type
     logical :: rddipgrad = .false.
     real(wp),allocatable :: dipgrad(:,:)
 
+    !> other properties
+    logical,allocatable :: getsasa(:) 
+
 !>--- API constructs
     integer  :: tblitelvl = 2
     real(wp) :: etemp = 300.0_wp

--- a/src/calculator/calculator.F90
+++ b/src/calculator/calculator.F90
@@ -22,9 +22,9 @@ module crest_calculator
   use iso_fortran_env,only:wp => real64,int64
   use strucrd
   use calc_type
+  use crest_calculator_printout
 !>--- potentials and API's
   use subprocess_engrad !> driver exports for subprocesses
-  use lj
   use api_engrad  !> contains many potentials
 !>--- other
   use constraints
@@ -41,10 +41,13 @@ module crest_calculator
   public :: calcdata              !> calculator main object
   public :: calculation_settings  !> different calculation objects (levels) within calcdata
   public :: jobtype               !> calculation type ID's
+  public :: get_dipoles
 !>--- RE-EXPORT of constraints
   public :: constraint
   public :: scantype
   public :: calc_constraint
+!>--- RE-EXPORT of printout routines
+  public :: calculation_summary
 !=========================================================================================!
 
 !>--- global engrad call counter
@@ -765,26 +768,6 @@ contains  !> MODULE PROCEDURES START HERE
 #endif
   end subroutine calc_ONIOM_projection
 
-!==========================================================================================!
-
-   subroutine get_dipoles(calc,diptmp)
-!*********************************************
-!* Collect the x y and z dipole moments for
-!* each calculation level in one array diptmp
-!*********************************************
-       implicit none
-       type(calcdata),intent(inout) :: calc
-       real(wp),allocatable,intent(out) :: diptmp(:,:)
-       integer :: i,j,k,l,m
-
-       m = calc%ncalculations
-       allocate(diptmp(3,m), source=0.0_wp) 
-       do i=1,m
-         if(calc%calcs(i)%rddip)then
-            diptmp(1:3,i) = calc%calcs(i)%dipole(1:3)
-         endif
-       enddo
-   end subroutine get_dipoles
 !==========================================================================================!
 !==========================================================================================!
 end module crest_calculator

--- a/src/calculator/gfn0_api.F90
+++ b/src/calculator/gfn0_api.F90
@@ -49,7 +49,7 @@ module gfn0_api
   public :: gfn0_getwbos
   public :: gfn0_gen_occ
   public :: gfn0_print
-  public :: gfn0_getdipole
+  public :: gfn0_getdipole,gfn0_getqat
 
 !========================================================================================!
 !========================================================================================!
@@ -267,6 +267,23 @@ contains  !>--- Module routines start here
     dipole = matmul(mol%xyz,g0calc%wfn%q)
 #endif
   end subroutine gfn0_getdipole
+
+!========================================================================================!
+
+  subroutine gfn0_getqat(g0calc,mol,qat)
+!*****************************************
+!* obtain atomic charges from gfn0 wfn
+!* Note, these come directly from an EEQ!
+!*****************************************
+    implicit none
+    type(gfn0_data),intent(in) :: g0calc
+    type(coord),intent(in) :: mol
+    real(wp),intent(out) :: qat(mol%nat)
+    qat(:) = 0.0_wp
+#ifdef WITH_GFN0
+    qat(:) = g0calc%wfn%q(:)
+#endif
+  end subroutine gfn0_getqat
 
 !========================================================================================!
 !========================================================================================!

--- a/src/calculator/gfnff_api.F90
+++ b/src/calculator/gfnff_api.F90
@@ -38,6 +38,7 @@ module gfnff_api
   public :: gfnff_sp
   public :: gfnff_printout
   public :: gfnff_getwbos
+  public :: gfnff_dump_sasa
 
 #ifndef WITH_GFNFF
   !> these are placeholders if no gfnff module is used!
@@ -148,6 +149,29 @@ contains  !> MODULE PROCEDURES START HERE
 #endif
   end subroutine gfnff_getwbos
 
+!========================================================================================!
+
+  subroutine gfnff_dump_sasa(ff_dat,nat,atlist)
+!***********************************************************
+!* Dumps cumulative SASA for all the atoms .true. in atlist
+!* into an file called fort.5454
+!***********************************************************
+    implicit none
+    type(gfnff_data),intent(in) :: ff_dat
+    logical,intent(in) :: atlist(nat)
+    integer,intent(in) :: nat
+    integer :: i
+    real(wp) :: sumsasa
+    if(allocated(ff_dat%solvation))then
+      if(allocated(ff_dat%solvation%sasa))then
+        sumsasa = 0.0_wp
+        do i=1,nat
+          if(atlist(i)) sumsasa = sumsasa + ff_dat%solvation%sasa(i)
+        enddo
+        write(5454,*) sumsasa
+      endif
+    endif
+  end subroutine gfnff_dump_sasa
 !========================================================================================!
 !========================================================================================!
 end module gfnff_api

--- a/src/calculator/meson.build
+++ b/src/calculator/meson.build
@@ -17,6 +17,7 @@
 srcs += files(
   'calculator.F90',
   'calc_type.f90',
+  'printouts.F90',
   'constraints.f90',
   'gfn0_api.F90',
   'gfnff_api.F90',

--- a/src/calculator/printouts.F90
+++ b/src/calculator/printouts.F90
@@ -47,6 +47,7 @@ contains  !> MODULE PROCEDURES START HERE
 
     integer :: i,j,k,l
     real(wp) :: dip
+    real(wp),allocatable :: cn(:)
     logical :: pr,skiplen
     integer :: iunit
 
@@ -89,14 +90,20 @@ contains  !> MODULE PROCEDURES START HERE
 
 !>--- atomic charges
     if(any(calc%calcs(:)%rdqat))then
+      if(present(molnew))then
+        call mol%get_cn(cn,'cov')
+      else
+        call mol%get_cn(cn,'cov')
+      endif
       write (iunit,*)
-      write (iunit,*) 'Atomic charges:'
+      write (iunit,*) 'Atomic charges and covalent CN:'
       do k = 1,calc%ncalculations
         if (calc%calcs(k)%rdqat.and.allocated(calc%calcs(k)%qat)) then
           write (iunit,'("> ",a,i3,a)') 'Calculation level ',k,': '//calc%calcs(k)%shortflag
-          write (iunit,'(3x,a6,1x,a6,a12)') 'atom','type','charge'
+          write (iunit,'(3x,a6,1x,a6,a12,a12)') 'atom','type','charge','covCN'
           do j=1,mol%nat
-            write (iunit,'(3x,i6,1x,a6,f12.6)') j,i2e(mol%at(j),'nc'),calc%calcs(k)%qat(j)
+            write (iunit,'(3x,i6,1x,a6,2f12.6)') j,i2e(mol%at(j),'nc'), &
+            & calc%calcs(k)%qat(j), cn(j)
           enddo  
           write (iunit,*)
         end if

--- a/src/calculator/printouts.F90
+++ b/src/calculator/printouts.F90
@@ -72,7 +72,7 @@ contains  !> MODULE PROCEDURES START HERE
       write (iunit,*) 'Connectivity information (bond order):'
       do k = 1,calc%ncalculations
         if (calc%calcs(k)%rdwbo) then
-          write (iunit,'("> ",a,i0)') 'Calculation level ',k
+          write (iunit,'("> ",a,i3,a:)') 'Calculation level ',k,'; '//calc%calcs(k)%shortflag
           write (iunit,'(a12,a12,a10)') 'Atom A','Atom B','BO(A-B)'
           do i = 1,mol%nat
             do j = 1,i-1
@@ -87,6 +87,23 @@ contains  !> MODULE PROCEDURES START HERE
       write (iunit,'(a)') repeat('-',80)
     end if
 
+!>--- atomic charges
+    if(any(calc%calcs(:)%rdqat))then
+      write (iunit,*)
+      write (iunit,*) 'Atomic charges:'
+      do k = 1,calc%ncalculations
+        if (calc%calcs(k)%rdqat.and.allocated(calc%calcs(k)%qat)) then
+          write (iunit,'("> ",a,i3,a)') 'Calculation level ',k,': '//calc%calcs(k)%shortflag
+          write (iunit,'(3x,a6,1x,a6,a12)') 'atom','type','charge'
+          do j=1,mol%nat
+            write (iunit,'(3x,i6,1x,a6,f12.6)') j,i2e(mol%at(j),'nc'),calc%calcs(k)%qat(j)
+          enddo  
+          write (iunit,*)
+        end if
+      end do
+      write (iunit,'(a)') repeat('-',80)
+    endif
+
 !>--- Dipole moments
     if (any(calc%calcs(:)%rddip)) then
       write (iunit,*)
@@ -94,13 +111,12 @@ contains  !> MODULE PROCEDURES START HERE
       do k = 1,calc%ncalculations
         if (calc%calcs(k)%rddip) then
           dip = norm2(calc%calcs(k)%dipole)*autod
-          write (iunit,'("> ",a,i3,a,a10,a10,a10,a14)') 'Calculation level ',k,':', &
-          &                                             'x','y','z','tot (Debye)'
+          write (iunit,'("> ",a,i3,a:)') 'Calculation level ',k,': '//calc%calcs(k)%shortflag
+          write (iunit,'(2x,19x,3x,a10,a10,a10,a14)') 'x','y','z','tot (Debye)' 
           write (iunit,'(2x,a,3x,4f10.3)') 'total dipole moment',calc%calcs(k)%dipole(:),dip
           write (iunit,*)
         end if
       end do
-      write (iunit,*)
       write (iunit,'(a)') repeat('-',80)
     end if
 
@@ -137,14 +153,14 @@ contains  !> MODULE PROCEDURES START HERE
     if (calc%ncalculations > 1) then
       write (iunit,*)
       write (iunit,'(a)') '> Individual energies and gradient norms:'
-      write (iunit,'(24x,a18,a18)') 'Energy/Eh','||Grad||/Eh/a0'
+      write (iunit,'(24x,a18,a18,3x,a)') 'Energy/Eh','||Grad||/Eh/a0','Method'
       do k = 1,calc%ncalculations
         if (calc%calcs(k)%rdgrad) then
-          write (iunit,'(2x,a,i3,a,2f18.8)') 'Calculation level ',k,':', &
-          & calc%etmp(k),norm2(calc%grdtmp(:,:,k))
+          write (iunit,'(2x,a,i3,a,2f18.8,4x,a)') 'Calculation level ',k,':', &
+          & calc%etmp(k),norm2(calc%grdtmp(:,:,k)),calc%calcs(k)%shortflag
         else
-          write (iunit,'(2x,a,i3,a,f18.8,a18)') 'Calculation level ',k,':', &
-          & calc%etmp(k),'-'
+          write (iunit,'(2x,a,i3,a,f18.8,a18,4x,a)') 'Calculation level ',k,':', &
+          & calc%etmp(k),'-',calc%calcs(k)%shortflag
         end if
       end do
       if (calc%nconstraints > 0) then
@@ -158,7 +174,7 @@ contains  !> MODULE PROCEDURES START HERE
       write (iunit,'(a)',advance='no') '> Writing crest.engrad ...'
       flush (iunit)
       call write_engrad('crest.engrad',energy,grad)
-      write (iunit,*) 'done!'
+      write (iunit,*) 'done.'
     end if
 
 !>--- print output structure (if present)

--- a/src/calculator/printouts.F90
+++ b/src/calculator/printouts.F90
@@ -1,0 +1,196 @@
+! This file is part of crest.
+!
+! Copyright (C) 2024 Philipp Pracht
+!
+! crest is free software: you can redistribute it and/or modify it under
+! the terms of the GNU Lesser General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! crest is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU Lesser General Public License for more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with crest.  If not, see <https://www.gnu.org/licenses/>.
+
+module crest_calculator_printout
+!>--- types and readers
+  use calc_type
+  use crest_parameters
+  use strucrd
+  use gradreader_module
+  implicit none
+!=========================================================================================!
+!>--- private module variables and parameters
+  private
+  character(len=*),parameter :: partial = '∂E/∂'
+
+  public :: calculation_summary
+
+!========================================================================================!
+!========================================================================================!
+contains  !> MODULE PROCEDURES START HERE
+!========================================================================================!
+!========================================================================================!
+
+  subroutine calculation_summary(calc,mol,energy,grad,molnew,iounit,print)
+    implicit none
+    type(calcdata),intent(inout)    :: calc
+    type(coord),intent(in)          :: mol
+    real(wp),intent(in),optional    :: energy
+    real(wp),intent(in),optional    :: grad(3,mol%nat)
+    type(coord),intent(in),optional :: molnew
+    integer,intent(in),optional     :: iounit
+    logical,intent(in),optional     :: print
+
+    integer :: i,j,k,l
+    real(wp) :: dip
+    logical :: pr,skiplen
+    integer :: iunit
+
+!>--- optional arguments to local settings
+    if (present(iounit)) then
+      iunit = iounit
+    else
+      iunit = stdout
+    end if
+
+    if (present(print)) then
+      pr = print
+    else
+      pr = .true.
+    end if
+
+!>--- we might want to skip some printout for large systems...
+    skiplen = mol%nat > 100
+
+!>--- Bond orders
+    if (any(calc%calcs(:)%rdwbo)) then
+      write (iunit,*)
+      write (iunit,*) 'Connectivity information (bond order):'
+      do k = 1,calc%ncalculations
+        if (calc%calcs(k)%rdwbo) then
+          write (iunit,'("> ",a,i0)') 'Calculation level ',k
+          write (iunit,'(a12,a12,a10)') 'Atom A','Atom B','BO(A-B)'
+          do i = 1,mol%nat
+            do j = 1,i-1
+              if (calc%calcs(k)%wbo(i,j) > 0.01_wp) then
+                write (iunit,*) i,j,calc%calcs(k)%wbo(i,j)
+              end if
+            end do
+          end do
+        end if
+      end do
+      write (iunit,*)
+      write (iunit,'(a)') repeat('-',80)
+    end if
+
+!>--- Dipole moments
+    if (any(calc%calcs(:)%rddip)) then
+      write (iunit,*)
+      write (iunit,*) 'Molecular dipole moments (a.u.):'
+      do k = 1,calc%ncalculations
+        if (calc%calcs(k)%rddip) then
+          dip = norm2(calc%calcs(k)%dipole)*autod
+          write (iunit,'("> ",a,i3,a,a10,a10,a10,a14)') 'Calculation level ',k,':', &
+          &                                             'x','y','z','tot (Debye)'
+          write (iunit,'(2x,a,3x,4f10.3)') 'total dipole moment',calc%calcs(k)%dipole(:),dip
+          write (iunit,*)
+        end if
+      end do
+      write (iunit,*)
+      write (iunit,'(a)') repeat('-',80)
+    end if
+
+!>--- gradients
+    if (all(calc%calcs(:)%rdgrad.eqv..false.)) then
+      write (iunit,*)
+      write (iunit,'(a)') '> No gradients calculated'
+    else if (present(grad)) then
+      write (iunit,*)
+      write (iunit,'(a)') '> Final molecular gradient ( Eh/a0 ):'
+      write (iunit,'(13x,a,13x,a,13x,a)') partial//'x',partial//'y',partial//'z'
+      k = mol%nat-5
+      do i = 1,mol%nat
+        if (.not.skiplen) then
+          write (iunit,'(3f18.8)') grad(1:3,i)
+        else
+          if (i <= 5.or.i >= k) then
+            write (iunit,'(3f18.8)') grad(1:3,i)
+          elseif (i == 6) then
+            write (iunit,'(a18,a18,a18)') '<...>','<...>','<...>'
+          end if
+        end if
+      end do
+      write (iunit,'(a,f18.8,a)') '> Gradient norm:',norm2(grad),' Eh/a0'
+      if (skiplen) then
+        write (iunit,'(a)') "> (printout partially skipped due to system size)"
+        if (present(energy)) then
+          write (iunit,'(a)') "> (see crest.engrad for full gradient)"
+        end if
+      end if
+    end if
+
+!>--- individual energies and norms
+    if (calc%ncalculations > 1) then
+      write (iunit,*)
+      write (iunit,'(a)') '> Individual energies and gradient norms:'
+      write (iunit,'(24x,a18,a18)') 'Energy/Eh','||Grad||/Eh/a0'
+      do k = 1,calc%ncalculations
+        if (calc%calcs(k)%rdgrad) then
+          write (iunit,'(2x,a,i3,a,2f18.8)') 'Calculation level ',k,':', &
+          & calc%etmp(k),norm2(calc%grdtmp(:,:,k))
+        else
+          write (iunit,'(2x,a,i3,a,f18.8,a18)') 'Calculation level ',k,':', &
+          & calc%etmp(k),'-'
+        end if
+      end do
+      if (calc%nconstraints > 0) then
+        write (iunit,'(1x,a)') '(+ constraints contribution)'
+      end if
+    end if
+
+!>---- write gradient
+    if (present(grad).and.present(energy)) then
+      write (iunit,*)
+      write (iunit,'(a)',advance='no') '> Writing crest.engrad ...'
+      flush (iunit)
+      call write_engrad('crest.engrad',energy,grad)
+      write (iunit,*) 'done!'
+    end if
+
+!>--- print output structure (if present)
+    if (present(molnew)) then
+      write (iunit,*)
+      write (iunit,'(a)') repeat('-',80)
+      write (iunit,*)
+      write (iunit,'(1x,a)') '-----------------'
+      write (iunit,'(1x,a)') 'Output structure:'
+      write (iunit,'(1x,a)') '-----------------'
+      write (iunit,'(i6)') molnew%nat
+      write (iunit,*)
+      k = molnew%nat-5
+      do i = 1,molnew%nat
+        if (.not.skiplen) then
+          write (iunit,'(a3,3f18.8)') i2e(molnew%at(i),'nc'),molnew%xyz(1:3,i)*autoaa
+        else
+          if (i <= 5.or.i >= k) then
+            write (iunit,'(a2,3f18.8)') i2e(molnew%at(i),'nc'),molnew%xyz(1:3,i)*autoaa
+          elseif (i == 6) then
+            write (iunit,'(a18,a18,a18)') '<...>','<...>','<...>'
+          end if
+        end if
+      end do
+      if (skiplen) then
+        write (iunit,'(a)') "> (printout partially skipped due to system size)"
+        write (iunit,'(a)') "> (see crestopt.xyz for full structure)"
+      end if
+    end if
+
+  end subroutine calculation_summary
+
+!========================================================================================!
+!========================================================================================!
+end module crest_calculator_printout

--- a/src/cn.f90
+++ b/src/cn.f90
@@ -1,0 +1,537 @@
+! This file is part of crest.
+!
+! Copyright (C) 2024 Philipp Pracht
+!
+! crest is free software: you can redistribute it and/or modify it under
+! the terms of the GNU Lesser General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! crest is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU Lesser General Public License for more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with crest.  If not, see <https://www.gnu.org/licenses/>.
+
+module crest_cn_module
+  use crest_parameters
+  use miscdata,only:RCOV,PAULING_EN
+  implicit none
+!=========================================================================================!
+!>--- private module variables and parameters
+  private
+  real(wp),parameter :: k1 = 16.0_wp
+  real(wp),parameter :: sqrtpi = sqrt(pi)
+
+  !> CN type enumerator
+  type,private:: enum_cntype
+    integer :: exp = 1
+    integer :: erf = 2
+    integer :: erf_en = 3
+    integer :: gfn = 4
+    integer :: d4 = 5
+  end type enum_cntype
+  type(enum_cntype),parameter,private :: cn_ver = enum_cntype()
+
+  public :: calculate_CN
+  public :: calc_ncoord
+  interface calc_ncoord
+    module procedure cn_ncoord
+    module procedure cn_xcoord
+    module procedure cn_xcoord2
+  end interface calc_ncoord
+  public :: cn_ycoord
+  public :: cn_ycoord2
+
+!========================================================================================!
+!========================================================================================!
+contains  !> MODULE PROCEDURES START HERE
+!========================================================================================!
+!========================================================================================!
+
+  subroutine calculate_CN(nat,at,xyz,cn,cnthr,cntype,dcndr)
+!*********************************************************
+!* Universal CN calculator with several optional settings
+!* for customisation.
+!* The routine requires at least the following arguments:
+!*   nat - number of atoms
+!*   at  - atomic numbers
+!*   xyz - coordinates in Bohr
+!* Optional arguments:
+!*   cnthr  - pair distance cutoff in Bohr
+!*   cntype - string to select CN type (exp,erf,erf_en)
+!*   dcndr  - optional output cn derivatives
+!*********************************************************
+    implicit none
+    !> INPUT
+    integer,intent(in) :: nat
+    integer,intent(in) :: at(nat)
+    real(wp),intent(in) :: xyz(3,nat)
+    !> OUTPUT
+    real(wp),intent(out) :: cn(nat)
+    !> OPTIONAL
+    real(wp),intent(in),optional :: cnthr
+    character(len=*),intent(in),optional :: cntype
+    real(wp),intent(out),optional :: dcndr(:,:,:)
+    !> LOCAL
+    real(wp) :: cn_thr,cn_direct
+    integer :: cn_type,ati,atj
+    real(wp) :: rcovi,rcovj,rij(3),r2,r,rco
+    real(wp) :: damp,ddamp(3),den
+    integer :: i,j,k,l,iat,jat
+    logical :: deriv
+
+!>--- check options and defaults
+    if (present(cnthr)) then
+      cn_thr = cnthr**2  !> note the value will be squared!
+    else
+      cn_thr = 625.0_wp  !> 25.0^2 as in tblite
+    end if
+
+    cn_direct = 1.0_wp
+    if (present(cntype)) then
+      select case (cntype)
+      case ('exp')
+        cn_type = cn_ver%exp
+      case ('erf')
+        cn_type = cn_ver%erf
+      case ('erf_en') !> DO NOT USE, SPECIAL FOR CEH
+        cn_type = cn_ver%erf_en
+        cn_direct = -1.0_wp
+      case ('gfn')
+        cn_type = cn_ver%gfn
+      case ('d4','cov')
+        cn_type = cn_ver%d4
+      case default
+        cn_type = cn_ver%exp
+      end select
+    else
+      cn_type = cn_ver%exp
+    end if
+
+    if (present(dcndr)) then
+      deriv = .true.
+      dcndr(:,:,:) = 0.0_wp
+    else
+      deriv = .false.
+    end if
+
+    cn(:) = 0.0_wp
+!>--- actual calculation
+
+    do i = 1,nat
+      ati = at(i)
+      rcovi = RCOV(ati)
+
+      do j = 1,i-1
+        rij(:) = xyz(:,i)-xyz(:,j)
+        r2 = sum(rij**2)
+!>--- cycle cutoff
+        if (r2 > cn_thr) cycle
+        r = sqrt(r2)
+        atj = at(j)
+        rcovj = RCOV(atj)
+        rco = rcovi+rcovj
+
+!>--- select the correct CN version
+        select case (cn_type)
+        case (cn_ver%exp)
+          damp = cn_damp_exp(rco,r)
+          if (deriv) ddamp(:) = dcn_damp_exp(rco,r)*(rij(:)/r)
+        case (cn_ver%erf)
+          damp = cn_damp_erf(rco,r)
+          if (deriv) ddamp(:) = dcn_damp_erf(rco,r)*(rij(:)/r)
+        case (cn_ver%erf_en) !> DO NOT USE, SPECIAL FOR CEH
+          den = PAULING_EN(atj)-PAULING_EN(ati)
+          damp = cn_damp_erf_en(rco,r,den)
+          if (deriv) ddamp(:) = dcn_damp_erf_en(rco,r,den)*(rij(:)/r)
+        case (cn_ver%d4)
+          den = PAULING_EN(atj)-PAULING_EN(ati)
+          damp = cn_damp_d4(rco,r,den)
+          if (deriv) ddamp(:) = dcn_damp_d4(rco,r,den)*(rij(:)/r)
+        case (cn_ver%gfn)
+          damp = cn_damp_gfn(rco,r)
+          if (deriv) ddamp(:) = dcn_damp_gfn(rco,r)*(rij(:)/r)
+        end select
+
+        cn(i) = cn(i)+damp
+        if (i /= j) then
+          cn(j) = cn(j)+damp*cn_direct
+        end if
+        if (deriv) then
+          dcndr(:,i,i) = dcndr(:,i,i)+ddamp(:)
+          dcndr(:,i,j) = dcndr(:,i,j)+ddamp(:)*cn_direct
+          dcndr(:,j,i) = dcndr(:,j,i)-ddamp(:)
+          dcndr(:,j,j) = dcndr(:,j,j)-ddamp(:)*cn_direct
+        end if
+
+      end do
+    end do
+
+  end subroutine calculate_CN
+
+!=========================================================================================!
+!> old ncoord-based routines for compatibility
+!=========================================================================================!
+
+  subroutine cn_ncoord(nat,rcovin,iz,xyz,cn,cn_thr)
+!****************************************************************
+!* Basic version taking covalent radii and cn threshold as input
+!*****************************************************************
+    implicit none
+    !> INPUT
+    integer,intent(in) :: nat
+    real(wp),intent(in) :: rcovin(*)
+    integer,intent(in) :: iz(nat)
+    real(wp),intent(in) :: xyz(3,nat)
+    real(wp),intent(in) :: cn_thr
+    !> OUTPUT
+    real(wp),intent(out) :: cn(nat)
+    integer :: iat,i
+    real(wp) :: r,damp,xn,rr,rco,r2,rcovi,rcovj
+
+    do i = 1,nat
+      xn = 0.0d0
+      rcovi = rcovin(iz(i))
+      do iat = 1,nat
+        if (iat .ne. i) then
+          r2 = cn_help_rdist(nat,xyz,iat,i)
+          if (r2 .gt. cn_thr) cycle
+          r = sqrt(r2)
+          rcovj = rcovin(iz(iat))
+!> covalent distance in Bohr
+          rco = rcovi+rcovj
+          rr = rco/r
+!> counting function exponential has a better long-range behavior than MHGs inverse damping
+          damp = 1.d0/(1.d0+exp(-k1*(rr-1.0d0)))
+          xn = xn+damp
+        end if
+      end do
+      cn(i) = xn
+    end do
+  end subroutine cn_ncoord
+
+!=========================================================================================!
+
+  subroutine cn_ycoord(nat,rcovin,iz,xyz,cn,cn_thr)
+!**********************************************************
+!* modified verison that multiplies the damping factor
+!* by the atomic number. Created for the CONFCROSS routine
+!*
+!* IMPORTANT: THIS IS NOT AN ACTUAL CN!
+!**********************************************************
+    implicit none
+    !> INPUT
+    integer,intent(in) :: nat
+    real(wp),intent(in) :: rcovin(*)
+    integer,intent(in) :: iz(nat)
+    real(wp),intent(in) :: xyz(3,nat)
+    real(wp),intent(in) :: cn_thr
+    !> OUTPUT
+    real(wp),intent(out) :: cn(nat)
+    !> LOCAL
+    integer  :: iat,i
+    real(wp) :: r,damp,xn,rr,rco,r2,rcovi,rcovj
+
+    do i = 1,nat
+      xn = 0.0d0
+      rcovi = rcovin(iz(i))
+      do iat = 1,nat
+        if (iat .ne. i) then
+          r2 = cn_help_rdist(nat,xyz,iat,i)
+          if (r2 .gt. cn_thr) cycle
+          r = sqrt(r2)
+          rcovj = rcovin(iz(iat))
+!> covalent distance in Bohr
+          rco = rcovi+rcovj
+          rr = rco/r
+!> counting function exponential has a better long-range behavior than MHGs inverse damping
+          damp = 1.d0/(1.d0+exp(-k1*(rr-1.0d0)))
+          xn = xn+damp*real(iz(iat))
+        end if
+      end do
+      cn(i) = xn
+    end do
+  end subroutine cn_ycoord
+
+  subroutine cn_ycoord2(nat,rcovin,iz,xyz,cn,cn_thr,cthr,clash)
+!**********************************************************
+!* variation to the ycoord version that checks for clashes
+!* if a clash is detected, the routine exits early!
+!* Note the "CN" is NOT an output, but an INPUT argument,
+!* to be used in tandem with ycoord
+!**********************************************************
+    implicit none
+    !> INPUT
+    integer,intent(in) :: nat
+    real(wp),intent(in) :: rcovin(*)
+    integer,intent(in) :: iz(nat)
+    real(wp),intent(in) :: xyz(3,nat)
+    real(wp),intent(in) :: cn_thr
+    real(wp),intent(in) :: cthr
+    real(wp),intent(in) :: cn(nat)
+    !> OUTPUT
+    logical,intent(out)  :: clash
+    !> LOCAL
+    integer  :: iat,i
+    real(wp) :: r,damp,xn,rr,rco,r2,rcovi,rcovj
+
+    clash = .false.
+    do i = 1,nat
+      xn = 0.0d0
+      rcovi = rcovin(iz(i))
+      do iat = 1,nat
+        if (iat .ne. i) then
+          r2 = cn_help_rdist(nat,xyz,iat,i)
+          if (r2 .gt. cn_thr) cycle
+          r = sqrt(r2)
+          rcovj = rcovin(iz(iat))
+!> covalent distance in Bohr
+          rco = rcovi+rcovj
+          rr = rco/r
+!> counting function exponential has a better long-range behavior than MHGs inverse damping
+          damp = 1.d0/(1.d0+exp(-k1*(rr-1.0d0)))
+          xn = xn+damp*iz(iat)
+        end if
+      end do
+      if (abs(cn(i)-xn) .gt. cthr) then                  !   clash check
+        clash = .true.
+        return
+      end if
+    end do
+  end subroutine cn_ycoord2
+
+!=========================================================================================!
+
+  subroutine cn_xcoord(nat,iz,xyz,cn,bond)
+!*********************************************
+!* simple version of CN calculation routine
+!* using a predefined CN cutoff of 400.0
+!* Also outputs a "bond" matrix
+!********************************************
+    implicit none
+    !> INPUT
+    integer,intent(in) :: nat
+    integer,intent(in) :: iz(nat)
+    real(wp),intent(in) :: xyz(3,nat)
+    !> OUTPUT
+    real(wp),intent(out) :: cn(nat)
+    real(wp),intent(out) :: bond(nat,nat)
+    !> LOCAL
+    real(wp) :: cn_thr,dx,dy,dz,r,damp
+    real(wp) :: xn,rr,rco,r2,rcovi,rcovj
+    integer  :: iat,i
+    !> take a fixed cn_thr
+    !> and the global
+    cn_thr = 400.0d0
+    call cn_xcoord2(nat,iz,xyz,RCOV,cn,cn_thr,bond)
+  end subroutine cn_xcoord
+
+  subroutine cn_xcoord2(nat,iz,xyz,rcovin,cn,cn_thr,bond)
+!***********************************************
+!* A clean version using input arguments for
+!* rcov, cn_thr and outputting a "bond" matrix
+!***********************************************
+    implicit none
+    !> INPUT
+    integer,intent(in) :: nat
+    integer,intent(in) :: iz(nat)
+    real(wp),intent(in) :: xyz(3,nat)
+    real(wp),intent(in)  :: cn_thr
+    real(wp),intent(in)  :: rcovin(*)
+    !> OUTPUT
+    real(wp),intent(out) :: cn(nat)
+    real(wp),intent(out) :: bond(nat,nat)
+    !> LOCAL
+    integer :: iat,i
+    real(wp) :: r,damp,xn,rr,rco,r2,rcovi,rcovj
+    bond = 0.0d0
+    cn = 0.0d0
+    do i = 1,nat
+      xn = 0.0d0
+      rcovi = rcovin(iz(i))
+      do iat = 1,nat
+        if (iat .ne. i) then
+          r2 = cn_help_rdist(nat,xyz,iat,i)
+          if (r2 .gt. cn_thr) cycle
+          r = sqrt(r2)
+          rcovj = rcovin(iz(iat))
+!> covalent distance in Bohr
+          rco = (rcovi+rcovj)
+          rr = rco/r
+!> counting function exponential has a better long-range behavior than MHGs inverse damping
+          damp = 1.d0/(1.d0+exp(-k1*(rr-1.0d0)))
+          bond(iat,i) = damp
+          xn = xn+damp
+        end if
+      end do
+      cn(i) = xn
+    end do
+    return
+  end subroutine cn_xcoord2
+
+!========================================================================================!
+!> Helper functions and damping versions
+!========================================================================================!
+
+  function cn_help_rdist(nat,xyz,iat,jat) result(r2)
+    implicit none
+    integer,intent(in) :: nat,iat,jat
+    real(wp),intent(in) :: xyz(3,nat)
+    real(wp) :: dx,dy,dz,r2
+    dx = xyz(1,iat)-xyz(1,jat)
+    dy = xyz(2,iat)-xyz(2,jat)
+    dz = xyz(3,iat)-xyz(3,jat)
+    r2 = dx*dx+dy*dy+dz*dz
+  end function cn_help_rdist
+
+  function cn_damp_exp(rco,r) result(damp)
+!*****************************************
+!* classic exponential CN damping factor
+!*****************************************
+    implicit none
+    real(wp) :: damp
+    real(wp),intent(in) :: rco,r
+    real(wp),parameter :: kcn = 16.0_wp
+    damp = 1.0_wp/(1.0_wp+exp(-kcn*(rco/r-1.0_wp)))
+  end function cn_damp_exp
+  function dcn_damp_exp(rco,r) result(ddamp)
+!**********************************************
+!* derivative of exponential CN damping factor
+!***********************************************
+    implicit none
+    real(wp) :: ddamp
+    real(wp),intent(in) :: rco,r
+    real(wp) :: tmp
+    real(wp),parameter :: kcn = 16.0_wp
+    tmp = exp(-kcn*(rco/r-1.0_wp))
+    ddamp = (-kcn*rco*tmp)/(r**2*((tmp+1.0_wp)**2))
+  end function dcn_damp_exp
+
+  function cn_damp_erf(rco,r) result(damp)
+!*************************
+!* erf-CN damping factor
+!*************************
+    implicit none
+    real(wp) :: damp
+    real(wp),intent(in) :: rco,r
+    real(wp),parameter :: kcn = 2.60_wp
+    damp = 0.5_wp*(1.0_wp+erf(-kcn*(r-rco)/rco))
+  end function cn_damp_erf
+  function dcn_damp_erf(rco,r) result(ddamp)
+!**************************************
+!* derivative of erf-CN damping factor
+!**************************************
+    implicit none
+    real(wp) :: ddamp
+    real(wp),intent(in) :: rco,r
+    real(wp) :: tmp
+    real(wp),parameter :: kcn = 2.60_wp
+    tmp = exp(-(kcn*(r-rco)/rco)**2)
+    ddamp = (-kcn*tmp)/(rco*sqrtpi)
+  end function dcn_damp_erf
+
+  function cn_damp_gfn(rco,r) result(damp)
+!***************************************
+!* double-exponential CN damping factor
+!***************************************
+    implicit none
+    real(wp) :: damp
+    real(wp),intent(in) :: rco,r
+    real(wp) :: dampa,dampb,rcob
+    !> Steepness of first counting function
+    real(wp),parameter :: ka = 10.0_wp
+    !> Steepness of second counting function
+    real(wp),parameter :: kb = 20.0_wp
+    !> Offset of the second counting function
+    real(wp),parameter :: r_shift = 2.0_wp
+    dampa = 1.0_wp/(1.0_wp+exp(-ka*(rco/r-1.0_wp)))
+    rcob = rco+r_shift
+    dampb = 1.0_wp/(1.0_wp+exp(-kb*(rcob/r-1.0_wp)))
+    damp = dampa*dampb
+  end function cn_damp_gfn
+  function dcn_damp_gfn(rco,r) result(ddamp)
+!*****************************************************
+!* derivative of double-exponential CN damping factor
+!*****************************************************
+    implicit none
+    real(wp) :: ddamp
+    real(wp),intent(in) :: rco,r
+    real(wp) :: tmp
+    real(wp) :: dampa,dampb,rcob
+    real(wp) :: ddampa,ddampb
+    !> Steepness of first counting function
+    real(wp),parameter :: ka = 10.0_wp
+    !> Steepness of second counting function
+    real(wp),parameter :: kb = 20.0_wp
+    !> Offset of the second counting function
+    real(wp),parameter :: r_shift = 2.0_wp
+    dampa = 1.0_wp/(1.0_wp+exp(-ka*(rco/r-1.0_wp)))
+    rcob = rco+r_shift
+    dampb = 1.0_wp/(1.0_wp+exp(-kb*(rcob/r-1.0_wp)))
+    tmp = exp(-ka*(rco/r-1._wp))
+    ddampa = (-ka*rco*tmp)/(r**2*((tmp+1.0_wp)**2))
+    tmp = exp(-kb*(rcob/r-1._wp))
+    ddampb = (-kb*rcob*tmp)/(r**2*((tmp+1.0_wp)**2))
+    ddamp = ddampa*dampb+dampa*ddampb
+  end function dcn_damp_gfn
+
+  function cn_damp_erf_en(rco,r,den) result(damp)
+!*********************************************************
+!* EN-dependent erf-CN damping factor (developed for CEH)
+!*********************************************************
+    implicit none
+    real(wp) :: damp
+    real(wp),intent(in) :: rco,r,den
+    damp = den*cn_damp_erf(rco,r)
+  end function cn_damp_erf_en
+  function dcn_damp_erf_en(rco,r,den) result(ddamp)
+!***********************************************************************
+!* derivative of EN-dependent erf-CN damping factor (developed for CEH)
+!***********************************************************************
+    implicit none
+    real(wp) :: ddamp
+    real(wp),intent(in) :: rco,r,den
+    ddamp = den*dcn_damp_erf(rco,r)
+  end function dcn_damp_erf_en
+
+  function cn_damp_d4(rco,r,den) result(damp)
+!*********************************************
+!* EN-dependent erf-CN damping factor from D4
+!*********************************************
+    implicit none
+    real(wp) :: damp
+    real(wp),intent(in) :: rco,r,den
+    real(wp) :: tmp,tmperf
+    real(wp),parameter :: k4 = 4.10451_wp
+    real(wp),parameter :: k5 = 19.08857_wp
+    real(wp),parameter :: k6 = 2*11.28174_wp**2
+    real(wp),parameter :: kcn = 7.50_wp
+    tmp = k4*exp(-((abs(den)+k5)**2)/k6)
+    tmperf = 0.5_wp*(1.0_wp+erf(-kcn*(r-rco)/rco))
+    damp = tmp*tmperf
+!    damp = tmp*cn_damp_erf(rco,r)
+  end function cn_damp_d4
+  function dcn_damp_d4(rco,r,den) result(ddamp)
+!***********************************************************
+!* derivative of EN-dependent erf-CN damping factor from D4
+!***********************************************************
+    implicit none
+    real(wp) :: ddamp
+    real(wp),intent(in) :: rco,r,den
+    real(wp) :: tmp,dtmperf,tmp2
+    real(wp),parameter :: k4 = 4.10451_wp
+    real(wp),parameter :: k5 = 19.08857_wp
+    real(wp),parameter :: k6 = 2*11.28174_wp**2
+    real(wp),parameter :: kcn = 7.50_wp
+    tmp = k4*exp(-(abs(den)+k5)**2/k6)
+    tmp2 = exp(-(kcn*(r-rco)/rco)**2)
+    dtmperf = (-kcn*tmp2)/(rco*sqrtpi)
+    ddamp = tmp*dtmperf
+  end function dcn_damp_d4
+
+!========================================================================================!
+!========================================================================================!
+end module crest_cn_module

--- a/src/confparse.f90
+++ b/src/confparse.f90
@@ -1782,6 +1782,8 @@ subroutine parseflags(env,arg,nra)
         env%docking_qcg_flag = ''
       case ('-fin_opt_gfn2')
         env%final_gfn2_opt = .true.
+      case ('-no_fin_opt_gfn2')
+        env%final_gfn2_opt = .false.
       case ('-directed') !> specify the directed list
         env%qcg_flag = .true.
         ctmp = trim(arg(i + 1))

--- a/src/cregen.f90
+++ b/src/cregen.f90
@@ -754,6 +754,7 @@ subroutine cregen_topocheck(ch,env,checkez,nat,nall,at,xyz,comments,newnall)
   use strucrd
   use miscdata,only:rcov
   use utilities
+  use crest_cn_module
   implicit none
   type(systemdata) :: env    ! MAIN STORAGE OS SYSTEM DATA
   integer,intent(in) :: ch ! printout channel
@@ -791,7 +792,7 @@ subroutine cregen_topocheck(ch,env,checkez,nat,nall,at,xyz,comments,newnall)
   allocate (bond(nat,nat),cn(nat),source=0.0_wp)
   cn = 0.0d0
   bond = 0.0d0
-  call xcoord2(nat,atdum,cref,rcov,cn,400.0_wp,bond)
+  call calc_ncoord(nat,atdum,cref,rcov,cn,400.0_wp,bond)
 
   if (allocated(env%excludeTOPO)) then
     call bondtotopo_excl(nat,at,bond,cn,ntopo,toporef,neighmat,env%excludeTOPO)
@@ -829,7 +830,7 @@ subroutine cregen_topocheck(ch,env,checkez,nat,nall,at,xyz,comments,newnall)
     discard = .false.
     cn = 0.0d0
     bond = 0.0d0
-    call xcoord2(nat,at,c1,rcov,cn,400.0_wp,bond)
+    call calc_ncoord(nat,at,c1,rcov,cn,400.0_wp,bond)
     if (allocated(env%excludeTOPO)) then
       call bondtotopo_excl(nat,at,bond,cn,ntopo,topo,neighmat,env%excludeTOPO)
     else
@@ -1840,6 +1841,7 @@ subroutine cregen_EQUAL(ch,nat,nall,at,xyz,group,athr,rotfil)
   use crest_data
   use strucrd
   use miscdata,only:rcov
+  use crest_cn_module
   use utilities
   implicit none
   integer,intent(in) :: ch
@@ -2161,7 +2163,7 @@ subroutine cregen_EQUAL(ch,nat,nall,at,xyz,group,athr,rotfil)
         irr = glist(ir,ig)
         call distance(n,xyz(:,:,irr),sd)   !> distance matrix
         cdum(1:3,1:n) = xyz(1:3,1:n,irr)
-        call ncoord(n,rcov,at,cdum,cn,500.0d0)
+        call calculate_CN(n,at,cdum,cn)
         do i = 1,n-1
           do j = i+1,n
             jfake(lin(j,i)) = cn(i)*cn(j)*sqrt(dble(at(i)*at(j))) &

--- a/src/flexi.F90
+++ b/src/flexi.F90
@@ -26,6 +26,7 @@ subroutine flexi(mol,rednat,includeAtom,flex)
   use strucrd
   use zdata,only:readwbo
   use miscdata, only: rcov
+  use crest_cn_module
   implicit none
   !> INPUT
   type(coord),intent(in) :: mol                  !> input molecule
@@ -61,7 +62,7 @@ subroutine flexi(mol,rednat,includeAtom,flex)
     at = mol%at
     xyz = mol%xyz
   end if
-  call ncoord(rn,rcov,at,xyz,cn,400.0d0)
+  call calculate_CN(rn,at,xyz,cn)
 
 !>--- map the new (reduced) coordinate order to the original
   j = 0

--- a/src/identifiers.f90
+++ b/src/identifiers.f90
@@ -495,6 +495,7 @@ end subroutine methyl_autocomplete
 
 subroutine get_methyl(n,xyz,at,eqv)
   use crest_parameters,only:wp
+  use crest_cn_module
   implicit none
   integer,intent(in)  :: n                    ! number of atoms
   real(wp),intent(in) :: xyz(3,n)             ! coordinates
@@ -517,7 +518,7 @@ subroutine get_methyl(n,xyz,at,eqv)
 
   cn = 0.0d0
   bond = 0.0d0
-  call xcoord(n,at,xyz,cn,bond)
+  call calc_ncoord(n,at,xyz,cn,bond)
 
   eqv = 0
 

--- a/src/legacy_algos/cregen_old.f90
+++ b/src/legacy_algos/cregen_old.f90
@@ -33,6 +33,7 @@ subroutine cregen2(env)
       use miscdata, only: rcov
       use utilities
       use omp_lib
+      use crest_cn_module
       implicit none
       type(systemdata) :: env    ! MAIN STORAGE OS SYSTEM DATA
 
@@ -222,9 +223,9 @@ subroutine cregen2(env)
            k=k+1
           endif
         enddo 
-        call ncoord(rednat,rcov,atr,c1r,cn0,500.0d0)
+        call calc_ncoord(rednat,rcov,atr,c1r,cn0,500.0d0)
       else
-        call ncoord(n,rcov,at,c1,cn0,500.0d0)
+        call calc_ncoord(n,rcov,at,c1,cn0,500.0d0)
       endif
 
 !c read file
@@ -250,7 +251,7 @@ subroutine cregen2(env)
          l1=distcheck(n,c1)  ! distance check
          cnorm=sum(abs(c1))
          if(abs(erj).gt.1.d-6.and.cnorm.gt.1.d-6.and.l1) &
-      &  call ncoord(n,rcov,at,c1,cn,500.0d0)    ! further check for reactions based on CN
+      &  call calc_ncoord(n,rcov,at,c1,cn,500.0d0)    ! further check for reactions based on CN
          k2=0        
          do i=1,n
             if(.not.(cn0(i).gt.0))cycle
@@ -288,7 +289,7 @@ subroutine cregen2(env)
          l1=distcheck(rednat,c1r)  ! distance check
          cnorm=sum(abs(c1r))
          if(abs(erj).gt.1.d-6.and.cnorm.gt.1.d-6.and.l1) &
-      &  call ncoord(rednat,rcov,atr,c1r,cn,500.0d0)    ! further check for reactions based on CN
+      &  call calc_ncoord(rednat,rcov,atr,c1r,cn,500.0d0)    ! further check for reactions based on CN
          k2=0
          do i=1,rednat
             !if(abs((cn(i)-cn0(i)))/cn0(i).gt.0.3) k2=1
@@ -1193,7 +1194,7 @@ subroutine cregen2(env)
          irr=glist(ir,ig)
          call distance(n,xyz(:,:,irr),sd)   ! distance matrix
          c1(1:3,1:n)=xyz(1:3,1:n,irr)
-         call ncoord(n,rcov,at,c1,cn,500.0d0)
+         call calc_ncoord(n,rcov,at,c1,cn,500.0d0)
          do i=1,n-1
             do j=i+1,n
                jfake(lin(j,i))=cn(i)*cn(j)*sqrt(dble(at(i)*at(j))) &

--- a/src/legacy_algos/reactor.f90
+++ b/src/legacy_algos/reactor.f90
@@ -577,6 +577,7 @@ subroutine reactorneighbours(nat,at,xyz,bond,ndim,ngh)
     use crest_parameters, only: wp, sp
     use miscdata, only: rcov
     use utilities
+    use crest_cn_module
     implicit none
     integer,intent(in) :: nat
     integer,intent(in) :: at(nat)
@@ -592,7 +593,7 @@ subroutine reactorneighbours(nat,at,xyz,bond,ndim,ngh)
 
     ngh=0 !reset
     allocate(cn(nat))
-    call xcoord2(nat,at,xyz,rcov,cn,800.0_wp,bond) 
+    call calc_ncoord(nat,at,xyz,rcov,cn,800.0_wp,bond) 
 
     do i=1,nat
       rcn=floor(cn(i))

--- a/src/legacy_algos/zsort.f90
+++ b/src/legacy_algos/zsort.f90
@@ -163,6 +163,7 @@ subroutine zsort
 end subroutine zsort
 
 subroutine recursive_zmat(xyz,at,nat,na,nb,nc,geo)
+  use crest_cn_module
   implicit none
 !     recursive Z matrix generation
 !     i/o block
@@ -187,7 +188,7 @@ subroutine recursive_zmat(xyz,at,nat,na,nb,nc,geo)
   nb = 0
   nc = 0
 !     code
-  call xcoord(nat,at,xyz,cn,bond)
+  call calc_ncoord(nat,at,xyz,cn,bond)
   do i = 1,nat
 !       j=maxloc(cn,1)
     if (.not. taken(i)) then

--- a/src/legacy_wrappers.f90
+++ b/src/legacy_wrappers.f90
@@ -55,6 +55,7 @@ subroutine env2calc(env,calc,molin)
   if( env%crestver == crest_sp )then
     cal%rdwbo = .true.
     cal%rddip = .true.
+    cal%rdqat = .true.
   endif
 
   !> implicit solvation

--- a/src/meson.build
+++ b/src/meson.build
@@ -38,6 +38,7 @@ srcs += files(
   'choose_settings.f90',
   'classes.f90',
   'cleanup.f90',
+  'cn.f90',
   'compress.f90',
   'confparse.f90',
   'cregen.f90',

--- a/src/miscdata.f90
+++ b/src/miscdata.f90
@@ -129,4 +129,33 @@ module miscdata
    & 2.17695_wp, 2.21705_wp]
 !&>
 
+!&<
+   !> Pauling electronegativities, used for the covalent coordination number.
+   real(wp), parameter :: pauling_en(118) = [ &
+   & 2.20_wp,3.00_wp, & ! H,He
+   & 0.98_wp,1.57_wp,2.04_wp,2.55_wp,3.04_wp,3.44_wp,3.98_wp,4.50_wp, & ! Li-Ne
+   & 0.93_wp,1.31_wp,1.61_wp,1.90_wp,2.19_wp,2.58_wp,3.16_wp,3.50_wp, & ! Na-Ar
+   & 0.82_wp,1.00_wp, & ! K,Ca
+   &                 1.36_wp,1.54_wp,1.63_wp,1.66_wp,1.55_wp, & ! Sc-
+   &                 1.83_wp,1.88_wp,1.91_wp,1.90_wp,1.65_wp, & ! -Zn
+   &                 1.81_wp,2.01_wp,2.18_wp,2.55_wp,2.96_wp,3.00_wp, & ! Ga-Kr
+   & 0.82_wp,0.95_wp, & ! Rb,Sr
+   &                 1.22_wp,1.33_wp,1.60_wp,2.16_wp,1.90_wp, & ! Y-
+   &                 2.20_wp,2.28_wp,2.20_wp,1.93_wp,1.69_wp, & ! -Cd
+   &                 1.78_wp,1.96_wp,2.05_wp,2.10_wp,2.66_wp,2.60_wp, & ! In-Xe
+   & 0.79_wp,0.89_wp, & ! Cs,Ba
+   &         1.10_wp,1.12_wp,1.13_wp,1.14_wp,1.15_wp,1.17_wp,1.18_wp, & ! La-Eu
+   &         1.20_wp,1.21_wp,1.22_wp,1.23_wp,1.24_wp,1.25_wp,1.26_wp, & ! Gd-Yb
+   &                 1.27_wp,1.30_wp,1.50_wp,2.36_wp,1.90_wp, & ! Lu-
+   &                 2.20_wp,2.20_wp,2.28_wp,2.54_wp,2.00_wp, & ! -Hg
+   &                 1.62_wp,2.33_wp,2.02_wp,2.00_wp,2.20_wp,2.20_wp, & ! Tl-Rn
+   ! only dummies below
+   & 1.50_wp,1.50_wp, & ! Fr,Ra
+   &         1.50_wp,1.50_wp,1.50_wp,1.50_wp,1.50_wp,1.50_wp,1.50_wp, & ! Ac-Am
+   &         1.50_wp,1.50_wp,1.50_wp,1.50_wp,1.50_wp,1.50_wp,1.50_wp, & ! Cm-No
+   &                 1.50_wp,1.50_wp,1.50_wp,1.50_wp,1.50_wp, & ! Rf-
+   &                 1.50_wp,1.50_wp,1.50_wp,1.50_wp,1.50_wp, & ! Rf-Cn
+   &                 1.50_wp,1.50_wp,1.50_wp,1.50_wp,1.50_wp,1.50_wp ] ! Nh-Og
+!&>
+
 end module miscdata

--- a/src/parsing/parse_calcdata.f90
+++ b/src/parsing/parse_calcdata.f90
@@ -269,6 +269,7 @@ contains !> MODULE PROCEDURES START HERE
       case ('ceh')
         job%id = jobtype%tblite
         job%tblitelvl = xtblvl%ceh
+        job%rdgrad = .false.
       case ('gfn0','gfn0-xtb')
         job%id = jobtype%gfn0
       case ('gfn0*','gfn0*-xtb')
@@ -332,8 +333,10 @@ contains !> MODULE PROCEDURES START HERE
         job%tblitelvl = xtblvl%ipea1
       case ('ceh')
         job%tblitelvl = xtblvl%ceh
+        job%rdgrad = .false.
       case ('eeq','d4eeq')
         job%tblitelvl = xtblvl%eeq
+        job%rdgrad=.false.
       case default
         job%tblitelvl = xtblvl%unknown
       end select

--- a/src/parsing/parse_calcdata.f90
+++ b/src/parsing/parse_calcdata.f90
@@ -416,6 +416,8 @@ contains !> MODULE PROCEDURES START HERE
       job%rdwbo = val
     case ('rddip','rddipole')
       job%rddip = val
+    case ('rdqat','rdchrg')
+      job%rdqat = val
     case ('dipgrad')
       job%rddipgrad = val
     case ('rdgrad')

--- a/src/qcg/solvtool.f90
+++ b/src/qcg/solvtool.f90
@@ -534,7 +534,7 @@ subroutine qcg_grow(env, solu, solv, clus, tim)
             env%potscal = 0.8_wp
          end if
          write (*, *)
-         write (*, '(2x,''Water as solvent recognized, &
+         write (*, '(2x,''Water as solvent recognized,&
                  & adjusting scaling factor for outer wall pot to '',F4.2)')&
                 & env%potscal
          write (*, *)
@@ -574,7 +574,6 @@ subroutine qcg_grow(env, solu, solv, clus, tim)
 ! Start Loop
 !--------------------------------------------------------
    do iter = 1, max_cycle
-
       e_there = .false.
       success = .false.
       high_e = .false.
@@ -670,6 +669,7 @@ subroutine qcg_grow(env, solu, solv, clus, tim)
       success = .false.
 
 !--- Cluster restart, if interaction energy not negativ (wall pot. too small)
+      gfnver_tmp = env%gfnver !> backup original level of theory
       do while (.not. success)
 !--- Cluster optimization
          if (env%cts%used) then
@@ -682,7 +682,7 @@ subroutine qcg_grow(env, solu, solv, clus, tim)
          end if
 
 !--- Interaction energy
-         gfnver_tmp = env%gfnver
+         !gfnver_tmp = env%gfnver
          env%gfnver = env%lmover
          gbsa_tmp = env%gbsa
          solv_tmp = env%solv

--- a/src/qcg/solvtool_misc.f90
+++ b/src/qcg/solvtool_misc.f90
@@ -115,7 +115,7 @@ subroutine xtb_lmo(env, fname)!,chrg)
    character(len=*), intent(in)     :: fname
    character(len=80)               :: pipe
    character(len=512)              :: jobcall
-   integer :: T,Tn
+   integer :: T,Tn,io
 
    pipe = ' > xtb.out 2>/dev/null'
 
@@ -125,7 +125,12 @@ subroutine xtb_lmo(env, fname)!,chrg)
 !---- jobcall, special gbsa treatment not needed, as the entire flag is included in env%solv
    write (jobcall, '(a,1x,a,1x,a,'' --sp --lmo '',a)') &
    &     trim(env%ProgName), trim(fname), trim(env%lmover), trim(pipe)
-   call command(trim(jobcall))
+   call command(trim(jobcall), exitstat=io)
+   
+   if(io /= 0)then
+     write(*,*) 'error in xtb_lmo'
+     stop
+   endif
 
 !--- cleanup
    call remove('wbo')

--- a/src/qcg/solvtool_misc.f90
+++ b/src/qcg/solvtool_misc.f90
@@ -279,8 +279,7 @@ subroutine opt_cluster(env, solu, clus, fname, without_pot)
    end if
 
 !--- Setting threads
-   call new_ompautoset(env,'auto',1,T,Tn)
-
+   call new_ompautoset(env,'subprocess',1,T,Tn)
 
 !--- Jobcall optimization
    if (.not. without_pot) then
@@ -872,10 +871,10 @@ subroutine rdxtbiffE(fname, m, n, e)
 
    implicit none
    integer :: m, n
-   character*(*) :: fname
+   character(len=*),intent(in) :: fname
    real*8 :: e(*)
 
-   character*128 :: line
+   character(len=128) :: line
    real*8 :: xx(10)
    integer :: ich, i, j, nn
 

--- a/src/qcg/solvtool_misc.f90
+++ b/src/qcg/solvtool_misc.f90
@@ -263,7 +263,7 @@ subroutine opt_cluster(env, solu, clus, fname, without_pot)
    character(len=*), intent(in)     :: fname
    logical, optional, intent(in)   :: without_pot
    character(len=80)               :: pipe
-   character(len=512)              :: jobcall
+   character(len=:),allocatable    :: jobcall
    integer :: T,Tn
 
    if (env%niceprint) then
@@ -282,13 +282,12 @@ subroutine opt_cluster(env, solu, clus, fname, without_pot)
    call new_ompautoset(env,'subprocess',1,T,Tn)
 
 !--- Jobcall optimization
-   if (.not. without_pot) then
-      write (jobcall, '(a,1x,a,1x,a,'' --opt '',f4.2,'' --input xcontrol > xtb_opt.out'',a)') &
-      &     trim(env%ProgName), trim(fname), trim(env%gfnver), env%optlev, trim(pipe)
-   else
-      write (jobcall, '(a,1x,a,1x,a,'' --opt '',f4.2,1x,a,'' > xtb_opt.out'',a)') &
-      &     trim(env%ProgName), trim(fname), trim(env%gfnver), env%optlev, trim(env%solv), trim(pipe)
-   end if
+   jobcall = trim(env%ProgName)//' '//trim(fname)//' --opt '//optlevflag(env%optlev) 
+   jobcall = trim(jobcall)//' '//trim(env%gfnver)
+   if(without_pot)then
+     jobcall = trim(jobcall)//' '//trim(env%solv)
+   endif
+   jobcall = trim(jobcall)//' > xtb_opt.out 2>/dev/null' 
    call command(trim(jobcall))
 
 ! cleanup
@@ -298,8 +297,9 @@ subroutine opt_cluster(env, solu, clus, fname, without_pot)
 
 !--- Jobcall SP for gbsa model
    if (.not. without_pot) then
-      write (jobcall, '(a,1x,a,1x,a,'' --sp '',a,'' > xtb_sp.out'',a)') &
-      &    trim(env%ProgName), 'xtbopt.coord', trim(env%gfnver), trim(env%solv), trim(pipe)
+      jobcall =  trim(env%ProgName)//' xtbopt.coord --sp '//trim(env%gfnver)
+      jobcall = trim(jobcall)//' '//trim(env%solv)
+      jobcall = trim(jobcall)//' > xtb_sp.out 2>/dev/null' 
    end if
    call command(trim(jobcall))
 

--- a/src/rigidconf/tree.f90
+++ b/src/rigidconf/tree.f90
@@ -59,6 +59,7 @@ subroutine rigidconf_tree(env,mol)
   use INTERNALS_mod
   use rigidconf_analyze
   use miscdata,only:rcov
+  use crest_cn_module
   implicit none
   !> INPUT/OUTPUT
   type(systemdata),intent(inout) :: env
@@ -98,7 +99,7 @@ subroutine rigidconf_tree(env,mol)
   !> data for new structure and reference checks
   logical,allocatable :: sane(:)
   type(coord) :: newmol
-  real(wp),allocatable :: cnref(:)
+  real(wp),allocatable :: cntoporef(:)
   real(wp) :: cthr,p
   integer :: nremain
 
@@ -209,8 +210,8 @@ subroutine rigidconf_tree(env,mol)
 
 !========================================================================================!
 !>--- Calculate reference CNs
-  allocate (cnref(mol%nat),source=0.0_wp)
-  call ycoord(mol%nat,rcov,mol%at,mol%xyz,cnref,100.0d0) !> refernce CNs
+  allocate (cntoporef(mol%nat),source=0.0_wp)
+  call cn_ycoord(mol%nat,rcov,mol%at,mol%xyz,cntoporef,100.0d0) !> refernce CNs
 
 !>--- Generate all the conformers and check for CN clashes
   allocate (zmat_new(3,mol%nat),source=0.0_wp)
@@ -229,7 +230,7 @@ subroutine rigidconf_tree(env,mol)
     call reconstruct_zmat_to_mol(mol%nat,mol%at,zmat_new,na,nb,nc,newmol)
 
 !>--- Check new structure for CN clashes w.r.t. reference and cthr
-    call ycoord2(newmol%nat,rcov,newmol%at,newmol%xyz,cnref,100.d0,cthr,sane(i)) !> CN clashes
+    call cn_ycoord2(newmol%nat,rcov,newmol%at,newmol%xyz,cntoporef,100.d0,cthr,sane(i)) !> CN clashes
     sane(i) = .not.sane(i)
 
 !>--- Dump to file

--- a/src/select.f90
+++ b/src/select.f90
@@ -26,16 +26,18 @@
 ! molvec: assignment vector of atom to fragment
 !=================================================================!
 subroutine mrec(molcount,xyz,nat,at,molvec)
+  use crest_parameters
+  use crest_cn_module
   implicit none
-  real*8 xyz(3,nat),cn(nat),bond(nat,nat)
-  integer nat,molvec(nat),i,molcount,at(nat)
-  logical taken(nat)
+  real(wp) :: xyz(3,nat),cn(nat),bond(nat,nat)
+  integer  :: nat,molvec(nat),i,molcount,at(nat)
+  logical  :: taken(nat)
   molvec = 0
   molcount = 1
   taken = .false.
   cn = 0.0d0
   bond = 0.0d0
-  call xcoord(nat,at,xyz,cn,bond)
+  call calc_ncoord(nat,at,xyz,cn,bond)
   do i = 1,nat
     if (.not.taken(i)) then
       molvec(i) = molcount
@@ -55,6 +57,7 @@ end subroutine mrec
 !=================================================================!
 subroutine mreclm(molcount,nat,at,xyz,molvec,bond,rcov,cn)
   use iso_fortran_env,only:wp => real64
+  use crest_cn_module
   implicit none
   integer :: molcount,nat
   integer :: at(nat),molvec(nat)
@@ -69,8 +72,7 @@ subroutine mreclm(molcount,nat,at,xyz,molvec,bond,rcov,cn)
   taken = .false.
   cn = 0.0d0
   bond = 0.0d0
-  !call xcoord(nat,at,xyz,cn,bond)
-  call xcoord2(nat,at,xyz,rcov,cn,400.0_wp,bond)
+  call calc_ncoord(nat,at,xyz,rcov,cn,400.0_wp,bond)
   bref = bond
   do i = 1,nat
     if (.not.taken(i)) then
@@ -86,10 +88,11 @@ end subroutine mreclm
 
 !==================================================================================!
 recursive subroutine neighbours(i,xyz,iat,taken,nat,cn,bond,molvec,molcnt)
+  use crest_parameters
   implicit none
-  real*8 xyz(3,nat),tr,xi(3),cn(nat),bond(nat,nat)
-  integer i,nat,molcnt,molvec(nat),j,iat(nat),icn,k
-  logical taken(nat)
+  real(wp) :: xyz(3,nat),tr,xi(3),cn(nat),bond(nat,nat)
+  integer  :: i,nat,molcnt,molvec(nat),j,iat(nat),icn,k
+  logical  :: taken(nat)
   tr = 2.0d0
 
   xi(1:3) = xyz(1:3,i)
@@ -105,199 +108,6 @@ recursive subroutine neighbours(i,xyz,iat,taken,nat,cn,bond,molvec,molcnt)
     end if
   end do
 end subroutine neighbours
-
-!================================================================================!
-! compute coordination numbers by adding an inverse damping function
-!================================================================================!
-subroutine xcoord(natoms,iz,xyz,cn,bond)
-  use miscdata,only:rcov
-  implicit none
-  integer iz(natoms),natoms,i,k1
-  real*8 xyz(3,natoms),cn(natoms)
-  real*8 cn_thr,bond(natoms,natoms)
-  integer iat
-  real*8 dx,dy,dz,r,damp,xn,rr,rco,r2,rcovi,rcovj
-
-  cn_thr = 400.0d0
-  k1 = 16
-  bond = 0.0d0
-  cn = 0.0d0
-  do i = 1,natoms
-    xn = 0.0d0
-    rcovi = rcov(iz(i))
-    do iat = 1,natoms
-      if (iat .ne. i) then
-        dx = xyz(1,iat)-xyz(1,i)
-        dy = xyz(2,iat)-xyz(2,i)
-        dz = xyz(3,iat)-xyz(3,i)
-        r2 = dx*dx+dy*dy+dz*dz
-        r = sqrt(r2)
-        if (r2 .gt. cn_thr) cycle
-        rcovj = rcov(iz(iat))
-! covalent distance in Bohr
-        rco = (rcovi+rcovj)*1.0  ! this scaling reduces the size of the clusters
-        rr = rco/r
-! counting function exponential has a better long-range behavior than MHGs inverse damping
-        damp = 1.d0/(1.d0+exp(-k1*(rr-1.0d0)))
-        bond(iat,i) = damp
-        xn = xn+damp
-      end if
-    end do
-    cn(i) = xn
-  end do
-end subroutine xcoord
-
-subroutine ycoord2(natoms,rcov,iz,xyz,cn,cn_thr,cthr,clash)
-  implicit none
-  real*8 k1,k3
-  parameter(k1=16)
-  parameter(k3=-4)
-  integer iz(*),natoms,i
-  real*8 xyz(3,*),cn(*),rcov(*)
-  real*8 cn_thr,cthr
-  logical clash
-
-  integer iat
-  real*8 dx,dy,dz,r,damp,xn,rr,rco,r2
-
-  clash = .false.
-  do i = 1,natoms
-    xn = 0.0d0
-    do iat = 1,natoms
-      if (iat .ne. i) then
-        dx = xyz(1,iat)-xyz(1,i)
-        dy = xyz(2,iat)-xyz(2,i)
-        dz = xyz(3,iat)-xyz(3,i)
-        r2 = dx*dx+dy*dy+dz*dz
-        if (r2 .gt. cn_thr) cycle
-        r = sqrt(r2)
-!c covalent distance in Bohr
-        rco = rcov(iz(i))+rcov(iz(iat))
-        rr = rco/r
-!c counting function exponential has a better long-range behavior than MHGs inverse damping
-        damp = 1.d0/(1.d0+exp(-k1*(rr-1.0d0)))
-        xn = xn+damp*iz(iat)
-      end if
-    end do
-    if (abs(cn(i)-xn) .gt. cthr) then                  !   clash check
-      clash = .true.
-      return
-    end if
-  end do
-end subroutine ycoord2
-
-subroutine ycoord(natoms,rcov,iz,xyz,cn,cn_thr)
-  implicit none
-  real*8 k1,k3
-  parameter(k1=16)
-  parameter(k3=-4)
-  integer iz(*),natoms,i
-  real*8 xyz(3,*),cn(*),rcov(*)
-  real*8 cn_thr
-
-  integer iat
-  real*8 dx,dy,dz,r,damp,xn,rr,rco,r2
-
-  do i = 1,natoms
-    xn = 0.0d0
-    do iat = 1,natoms
-      if (iat .ne. i) then
-        dx = xyz(1,iat)-xyz(1,i)
-        dy = xyz(2,iat)-xyz(2,i)
-        dz = xyz(3,iat)-xyz(3,i)
-        r2 = dx*dx+dy*dy+dz*dz
-        if (r2 .gt. cn_thr) cycle
-        r = sqrt(r2)
-!c covalent distance in Bohr
-        rco = rcov(iz(i))+rcov(iz(iat))
-        rr = rco/r
-!c counting function exponential has a better long-range behavior than MHGs inverse damping
-        damp = 1.d0/(1.d0+exp(-k1*(rr-1.0d0)))
-        xn = xn+damp*iz(iat)
-      end if
-    end do
-    cn(i) = xn
-  end do
-
-end subroutine ycoord
-
-subroutine ycoord3(natoms,iz,xyz,cn,cn_thr,bond)
-  use miscdata,only:rcov
-  implicit none
-  integer :: natoms      ! = n
-  integer :: iz(natoms)  ! = at
-  integer :: i,k1
-  real*8 xyz(3,natoms),cn(natoms)
-  real*8 cn_thr,bond(natoms,natoms)
-  integer iat
-  real*8 dx,dy,dz,r,damp,xn,rr,rco,r2,rcovi,rcovj
-
-  !cn_thr=1600.0d0
-  k1 = 16
-  bond = 0.0d0
-  cn = 0.0d0
-  do i = 1,natoms
-    xn = 0.0d0
-    !call setrcov(iz(i),rcovi)
-    rcovi = rcov(iz(i))
-    do iat = 1,natoms
-      if (iat .ne. i) then
-        dx = xyz(1,iat)-xyz(1,i)
-        dy = xyz(2,iat)-xyz(2,i)
-        dz = xyz(3,iat)-xyz(3,i)
-        r2 = dx*dx+dy*dy+dz*dz
-        r = sqrt(r2)
-        if (r2 .gt. cn_thr) cycle
-        !call setrcov(iz(iat),rcovj)
-        rcovj = rcov(iz(iat))
-!c covalent distance in Bohr
-        rco = rcovi+rcovj
-        rr = rco/r
-!            rr=rr*0.90d0
-!c counting function exponential has a better long-range behavior than MHGs inverse damping
-        damp = 1.d0/(1.d0+exp(-k1*(rr-1.0d0)))
-        bond(iat,i) = damp
-!            bond(i,iat)=damp
-        xn = xn+damp
-      end if
-    end do
-    cn(i) = xn
-  end do
-end subroutine ycoord3
-
-subroutine ncoord(natoms,rcov,iz,xyz,cn,cn_thr)
-  implicit none
-  real*8 :: k1,k3
-  parameter(k1=16)
-  parameter(k3=-4)
-  integer :: iz(*),natoms,i
-  real*8 :: xyz(3,*),cn(*),rcov(*)
-  real*8 :: cn_thr
-
-  integer :: iat
-  real*8 :: dx,dy,dz,r,damp,xn,rr,rco,r2
-
-  do i = 1,natoms
-    xn = 0.0d0
-    do iat = 1,natoms
-      if (iat .ne. i) then
-        dx = xyz(1,iat)-xyz(1,i)
-        dy = xyz(2,iat)-xyz(2,i)
-        dz = xyz(3,iat)-xyz(3,i)
-        r2 = dx*dx+dy*dy+dz*dz
-        if (r2 .gt. cn_thr) cycle
-        r = sqrt(r2)
-!c covalent distance in Bohr
-        rco = rcov(iz(i))+rcov(iz(iat))
-        rr = rco/r
-!c counting function exponential has a better long-range behavior than MHGs inverse damping
-        damp = 1.d0/(1.d0+exp(-k1*(rr-1.0d0)))
-        xn = xn+damp
-      end if
-    end do
-    cn(i) = xn
-  end do
-end subroutine ncoord
 
 !========================================================================================!
 

--- a/src/strucreader.f90
+++ b/src/strucreader.f90
@@ -41,6 +41,7 @@ module strucrd
   use geo
 !> element symbols
   use miscdata,only:PSE
+  use crest_cn_module, only: calculate_cn
   implicit none
 
 !=========================================================================================!
@@ -203,6 +204,7 @@ module strucrd
     procedure :: angle => coord_getangle        !> calculate angle between three atoms
     procedure :: dihedral => coord_getdihedral  !> calculate dihedral angle between four atoms
     procedure :: cutout => coord_getcutout      !> create a substructure 
+    procedure :: get_CN => coord_get_CN         !> calculate coordination number
   end type coord
 !=========================================================================================!
   !ensemble class. contains all structures of an ensemble
@@ -1428,8 +1430,21 @@ contains  !> MODULE PROCEDURES START HERE
     return
   end function coord_getcutout
 
+!==================================================================!
 
-
+  subroutine coord_get_CN(self,cn,cn_type,cn_thr,dcndr)
+    implicit none
+    class(coord) :: self
+    real(wp),intent(out),allocatable :: cn(:)
+    real(wp),intent(in),optional :: cn_thr
+    character(len=*),intent(in),optional :: cn_type
+    real(wp),intent(out),optional :: dcndr(3,self%nat,self%nat)
+    if(self%nat <= 0) return
+    if(.not.allocated(self%xyz) .or. .not.allocated(self%at)) return
+    allocate(cn(self%nat), source=0.0_wp)
+    call calculate_CN(self%nat, self%at, self%xyz, cn, &
+    & cntype=cn_type, cnthr=cn_thr, dcndr=dcndr)
+  end subroutine coord_get_CN
 
 !=========================================================================================!
 !=========================================================================================!

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,7 @@ set(
   "gfnff"
   "gfn0"
   "gfn0occ"
+  "CN"
   "optimization"
 )
 set(

--- a/test/main.f90
+++ b/test/main.f90
@@ -7,6 +7,7 @@ program tester
   use test_gfnff, only : collect_gfnff
   use test_gfn0, only: collect_gfn0
   use test_gfn0occ, only: collect_gfn0occ
+  use test_cn, only: collect_cn 
   use test_optimization, only: collect_optimization
   implicit none
   integer :: stat, is
@@ -23,6 +24,7 @@ program tester
     new_testsuite("gfnff", collect_gfnff),     &
     new_testsuite("gfn0", collect_gfn0),       &
     new_testsuite("gfn0occ", collect_gfn0occ), &
+    new_testsuite("CN",collect_CN),            &
     new_testsuite("optimization", collect_optimization) &
   ]
 !&>

--- a/test/test_CN.F90
+++ b/test/test_CN.F90
@@ -1,0 +1,369 @@
+module test_CN
+  use testdrive,only:new_unittest,unittest_type,error_type,check,test_failed
+  use crest_parameters
+  use testmol
+  use strucrd
+  use crest_cn_module
+  use miscdata,only:RCOV  !> D3 covalent radii
+  implicit none
+  private
+
+  public :: collect_CN
+
+  real(wp),parameter :: thr = 1.e-5
+
+!========================================================================================!
+!========================================================================================!
+contains  !> Unit tests for calculating coordination numbers
+!========================================================================================!
+!========================================================================================!
+
+!> Collect all exported unit tests
+  subroutine collect_CN(testsuite)
+    !> Collection of tests
+    type(unittest_type),allocatable,intent(out) :: testsuite(:)
+
+!&<
+    testsuite = [ &
+    new_unittest("CN(exp) calculation           ",test_cn_exp), &
+    new_unittest("CN(gfn) calculation           ",test_cn_gfn), &
+    new_unittest("CN(erf) calculation           ",test_cn_erf), &
+!    new_unittest("CN(erf/EN) calculation        ",test_cn_erf_en), &
+    new_unittest("CN(erf/D4) calculation        ",test_cn_d4),  &
+    new_unittest("CN calculation via coord type ",test_cn_coord)  &
+    ]
+!&>
+  end subroutine collect_CN
+
+!========================================================================================!
+
+  subroutine test_cn_exp(error)
+    type(error_type),allocatable,intent(out) :: error
+    type(coord) :: mol
+    real(wp),allocatable :: cn(:)
+    integer :: io
+    logical :: wr,pr
+    real(wp),allocatable :: bond(:,:)
+!&<
+    real(wp),parameter :: cn_ref(24) = reshape([&
+    & 4.055891127145659_wp, &
+    & 3.288889882015843_wp, &
+    & 3.513090304082208_wp, &
+    & 2.220376901140114_wp, &
+    & 3.637790405819880_wp, &
+    & 3.482378921657057_wp, &
+    & 3.173753862846316_wp, &
+    & 1.067653963029709_wp, &
+    & 3.162194988565337_wp, &
+    & 3.219594664750161_wp, &
+    & 1.066642405807029_wp, &
+    & 3.149745868662636_wp, &
+    & 4.079048157993642_wp, &
+    & 4.093458099252320_wp, &
+    & 0.998258561306359_wp, &
+    & 0.998521112348117_wp, &
+    & 0.998518471567465_wp, &
+    & 1.000789208143010_wp, &
+    & 0.998145405602563_wp, &
+    & 0.998002933550897_wp, &
+    & 0.998000732079435_wp, &
+    & 0.998213943231262_wp, &
+    & 0.998095785577331_wp, &
+    & 0.998094156726710_wp  ],shape(cn_ref))
+!&>
+
+    !> setup
+    call get_testmol('caffeine',mol)
+!    call mol%write('coord')
+    allocate (cn(mol%nat))
+    call calculate_CN(mol%nat,mol%at,mol%xyz,cn)
+!   write(*,'(F25.15)') cn
+!   write(*,'((F20.15,"_wp,")," &")') cn
+    if (any(abs(cn-cn_ref) > thr)) then
+      call test_failed(error,"Coordination number does not match")
+      print'(es21.14)',cn
+      print'("---")'
+      print'(es21.14)',cn_ref
+      print'("---")'
+      print'(es21.14)',cn-cn_ref
+    end if
+
+
+    deallocate (cn)
+  end subroutine test_cn_exp
+
+!========================================================================================!
+
+  subroutine test_cn_erf(error)
+    type(error_type),allocatable,intent(out) :: error
+    type(coord) :: mol
+    real(wp),allocatable :: cn(:)
+    integer :: io
+    logical :: wr,pr
+    real(wp),allocatable :: bond(:,:)
+!&<
+    real(wp),parameter :: cn_ref(24) = reshape([&
+    & 3.622643648420508_wp, &
+    & 3.405718465347867_wp, &
+    & 3.507245465631688_wp, &
+    & 2.486310140446890_wp, &
+    & 4.082546940409358_wp, &
+    & 4.081594016649126_wp, &
+    & 3.380301062250944_wp, &
+    & 1.234253454564075_wp, &
+    & 3.343427434675905_wp, &
+    & 3.487619595812383_wp, &
+    & 1.249505697640035_wp, &
+    & 3.316227492282645_wp, &
+    & 3.698556251266844_wp, &
+    & 3.736560853778984_wp, &
+    & 0.835607601692369_wp, &
+    & 0.837012229249737_wp, &
+    & 0.837010957128861_wp, &
+    & 0.850441048113596_wp, &
+    & 0.830336741440498_wp, &
+    & 0.832966244796499_wp, &
+    & 0.832940283784449_wp, &
+    & 0.830257575136063_wp, &
+    & 0.833483436263467_wp, &
+    & 0.833442705428422_wp  &
+    &  ],shape(cn_ref))
+!&>
+    !> setup
+    call get_testmol('caffeine',mol)
+    allocate (cn(mol%nat))
+    call calculate_CN(mol%nat,mol%at,mol%xyz,cn,cntype='erf')
+    !write(*,'((F20.15,"_wp,")," &")') cn
+    if (any(abs(cn-cn_ref) > thr)) then
+      call test_failed(error,"Coordination number does not match")
+      print'(es21.14)',cn
+      print'("---")'
+      print'(es21.14)',cn_ref
+      print'("---")'
+      print'(es21.14)',cn-cn_ref
+    end if
+
+
+    deallocate (cn)
+  end subroutine test_cn_erf
+
+!========================================================================================!
+
+  subroutine test_cn_gfn(error)
+    type(error_type),allocatable,intent(out) :: error
+    type(coord) :: mol
+    real(wp),allocatable :: cn(:),dcn(:,:,:)
+    integer :: io
+    logical :: wr,pr
+    real(wp),allocatable :: bond(:,:)
+!&<
+    real(wp),parameter :: cn_ref(24) = reshape([&
+    & 4.080787717742611_wp, &
+    & 3.605947418297714_wp, &
+    & 3.707376933085117_wp, &
+    & 2.507369342111704_wp, &
+    & 4.084010812746403_wp, &
+    & 4.014235318357683_wp, &
+    & 3.479735006842208_wp, &
+    & 1.228166602213276_wp, &
+    & 3.513131818377105_wp, &
+    & 3.565453679633609_wp, &
+    & 1.243466609796757_wp, &
+    & 3.486018352311430_wp, &
+    & 4.140527219855912_wp, &
+    & 4.172156631475451_wp, &
+    & 0.997681762757485_wp, &
+    & 0.996836574428603_wp, &
+    & 0.996829830734909_wp, &
+    & 1.009883794482724_wp, &
+    & 0.998871095489539_wp, &
+    & 0.995131864627251_wp, &
+    & 0.995121246092223_wp, &
+    & 0.999619334837355_wp, &
+    & 0.996233442007880_wp, &
+    & 0.996201406389150_wp &
+    &  ],shape(cn_ref))
+!&>
+    !> setup
+    call get_testmol('caffeine',mol)
+    allocate (cn(mol%nat),dcn(3,mol%nat,mol%nat))
+    call calculate_CN(mol%nat,mol%at,mol%xyz,cn,cntype='gfn',dcndr=dcn)
+    !write(*,'((F20.15,"_wp,")," &")') cn
+    !write(*,'(3(F20.15,"_wp,")," &")') dcn
+    if (any(abs(cn-cn_ref) > thr)) then
+      call test_failed(error,"Coordination number does not match")
+      print'(es21.14)',cn
+      print'("---")'
+      print'(es21.14)',cn_ref
+      print'("---")'
+      print'(es21.14)',cn-cn_ref
+    end if
+
+    deallocate (dcn,cn)
+  end subroutine test_cn_gfn
+
+!========================================================================================!
+
+  subroutine test_cn_erf_en(error)
+    type(error_type),allocatable,intent(out) :: error
+    type(coord) :: mol
+    real(wp),allocatable :: cn(:)
+    integer :: io
+    logical :: wr,pr
+    real(wp),allocatable :: bond(:,:)
+!&<
+    real(wp),parameter :: cn_ref(24) = reshape([&
+    & 0.000000000_wp, &
+    & 0.000000000_wp, &
+    & 0.000000000_wp, &
+    & 0.000000000_wp, &
+    & 0.000000000_wp, &
+    & 0.000000000_wp, &
+    & 0.000000000_wp, &
+    & 0.000000000_wp, &
+    & 0.000000000_wp, &
+    & 0.000000000_wp, &
+    & 0.000000000_wp, &
+    & 0.000000000_wp, &
+    & 0.000000000_wp, &
+    & 0.000000000_wp, &
+    & 0.000000000_wp, &
+    & 0.000000000_wp, &
+    & 0.000000000_wp, &
+    & 0.000000000_wp, &
+    & 0.000000000_wp, &
+    & 0.000000000_wp, &
+    & 0.000000000_wp, &
+    & 0.000000000_wp, &
+    & 0.000000000_wp, &
+    & 0.000000000_wp  &
+    &  ],shape(cn_ref))
+!&>
+    !> setup
+    call get_testmol('caffeine',mol)
+    allocate (cn(mol%nat))
+    call calculate_CN(mol%nat,mol%at,mol%xyz,cn,cntype='erf_en')
+    write(*,'((F20.15,"_wp,")," &")') cn
+!    if (any(abs(cn-cn_ref) > thr)) then
+!      call test_failed(error,"Coordination number does not match")
+!      print'(es21.14)',cn
+!      print'("---")'
+!      print'(es21.14)',cn_ref
+!      print'("---")'
+!      print'(es21.14)',cn-cn_ref
+!    end if
+!
+
+    deallocate (cn)
+  end subroutine test_cn_erf_en
+
+!========================================================================================!
+
+  subroutine test_cn_d4(error)
+    type(error_type),allocatable,intent(out) :: error
+    type(coord) :: mol
+    real(wp),allocatable :: cn(:)
+    integer :: io
+    logical :: wr,pr
+    real(wp),allocatable :: bond(:,:)
+!&<
+    real(wp),parameter :: cn_ref(24) = reshape([&
+    & 3.687259184149240_wp, &
+    & 2.867262205332734_wp, &
+    & 3.150724166180586_wp, &
+    & 1.893569777782766_wp, &
+    & 3.203211463839986_wp, &
+    & 3.080099878320893_wp, &
+    & 2.766851050499062_wp, &
+    & 0.858277785022996_wp, &
+    & 2.742941624230694_wp, &
+    & 2.714022969151142_wp, &
+    & 0.857488513179795_wp, &
+    & 2.737922550140081_wp, &
+    & 3.693785224461224_wp, &
+    & 3.700081658703103_wp, &
+    & 0.924156979713941_wp, &
+    & 0.924169842395564_wp, &
+    & 0.924168470344702_wp, &
+    & 0.925321663943406_wp, &
+    & 0.924123074464423_wp, &
+    & 0.923951547270359_wp, &
+    & 0.923952329637323_wp, &
+    & 0.924191441370459_wp, &
+    & 0.923896277881526_wp, &
+    & 0.923905844557051_wp &
+    &  ],shape(cn_ref))
+!&>
+    !> setup
+    call get_testmol('caffeine',mol)
+    allocate (cn(mol%nat))
+    call calculate_CN(mol%nat,mol%at,mol%xyz,cn,cntype='d4',cnthr=sqrt(1600.0_wp))
+    !write(*,'((F20.15,"_wp,")," &")') cn
+    if (any(abs(cn-cn_ref) > thr)) then
+      call test_failed(error,"Coordination number does not match")
+      print'(es21.14)',cn
+      print'("---")'
+      print'(es21.14)',cn_ref
+      print'("---")'
+      print'(es21.14)',cn-cn_ref
+    end if
+
+    deallocate (cn)
+  end subroutine test_cn_d4
+
+!========================================================================================!
+
+  subroutine test_cn_coord(error)
+    type(error_type),allocatable,intent(out) :: error
+    type(coord) :: mol
+    real(wp),allocatable :: cn(:)
+    integer :: io
+    logical :: wr,pr
+    real(wp),allocatable :: dcndr(:,:,:)
+!&<
+    real(wp),parameter :: cn_ref(24) = reshape([&
+    & 3.687259184149240_wp, &
+    & 2.867262205332734_wp, &
+    & 3.150724166180586_wp, &
+    & 1.893569777782766_wp, &
+    & 3.203211463839986_wp, &
+    & 3.080099878320893_wp, &
+    & 2.766851050499062_wp, &
+    & 0.858277785022996_wp, &
+    & 2.742941624230694_wp, &
+    & 2.714022969151142_wp, &
+    & 0.857488513179795_wp, &
+    & 2.737922550140081_wp, &
+    & 3.693785224461224_wp, &
+    & 3.700081658703103_wp, &
+    & 0.924156979713941_wp, &
+    & 0.924169842395564_wp, &
+    & 0.924168470344702_wp, &
+    & 0.925321663943406_wp, &
+    & 0.924123074464423_wp, &
+    & 0.923951547270359_wp, &
+    & 0.923952329637323_wp, &
+    & 0.924191441370459_wp, &
+    & 0.923896277881526_wp, &
+    & 0.923905844557051_wp &
+    &  ],shape(cn_ref))
+!&>
+    !> setup
+    call get_testmol('caffeine',mol)
+    call mol%get_cn(cn,'cov')
+    !write(*,'((F20.15,"_wp,")," &")') cn
+    if (any(abs(cn-cn_ref) > thr)) then
+      call test_failed(error,"Coordination number does not match")
+      print'(es21.14)',cn
+      print'("---")'
+      print'(es21.14)',cn_ref
+      print'("---")'
+      print'(es21.14)',cn-cn_ref
+    end if
+
+    deallocate (cn)
+  end subroutine test_cn_coord
+
+!========================================================================================!
+!========================================================================================!
+end module test_CN

--- a/test/test_optimization.F90
+++ b/test/test_optimization.F90
@@ -106,6 +106,7 @@ contains  !> Unit tests for using geometry optimization routines in CREST
     call sett%create('gfnff')
     call calc%add(sett)
     call get_testmol('methane',mol)
+    molnew = mol
     allocate (grad(3,mol%nat))
 
     !> calculation


### PR DESCRIPTION
- add note about OpenMP versions (relating to #285) in README.md
- fix I/O issue for multiple g98.out file writes
- singlepoint and optimization printout cleanup
- atomic charge readout for tblite, gfn0, and gfnff calculators
- restore MD restart file selection (`restart=<filename>` in `[dynamics]` block)
- Fix axis trafo bug causing #296 
- Address #297 and #294 