### PR TITLE
Guard CREGEN against empty conformer groups

### DIFF
--- a/src/cregen.f90
+++ b/src/cregen.f90
@@ -87,6 +87,7 @@ subroutine newcregen(env,quickset,infile)
 !>--- sorting arguments
   integer,allocatable :: gref(:),group(:)
   integer :: ng
+  integer :: i
   integer,allocatable :: degen(:,:)
 
 !>--- float data
@@ -241,6 +242,19 @@ subroutine newcregen(env,quickset,infile)
     ng = group(0)
     allocate (degen(3,ng))
     call cregen_groupinfo(nall,ng,group,degen)
+  else
+    ng = nall
+    if (ng > 0) then
+      allocate (degen(3,ng))
+      do i = 1, ng
+        degen(1,i) = 1
+        degen(2,i) = i
+        degen(3,i) = i
+      end do
+    else
+      allocate (degen(3,1))
+      degen = 0
+    end if
   end if
   if (sortRMSD2) then
     allocate (group(0:nall))
@@ -2194,6 +2208,7 @@ subroutine cregen_conffile(env,cname,nat,nall,at,xyz,comments,ng,degen)
   open (newunit=ich,file=trim(cname))
   do i = 1,ng
     k = degen(2,i)
+    if (k <= 0 .or. k > nall) cycle
     if (i .eq. 1.or.env%printscoords) then   !write a scoord.* for each conformer? scoord.1 is always written
       call getname1(i,newcomment)
       c0(:,:) = xyz(:,:,k)/bohr


### PR DESCRIPTION
## Reproduction

```
crest struc.xyz \
  --qcg water.xyz --nsolv 6 \
  --gfnff --T 12 --alpb water \
  --ensemble --md --mdtime 10 --wscal 1.0
```

Example command taken from <https://crest-lab.github.io/crest-docs/page/examples/qcg/example_5.html>.

On `master` (`c39758d`) this workflow aborts during the first CREGEN pass with:

```
Program received signal SIGSEGV: Segmentation fault - invalid memory reference.
#0  ... cregen_conffile_ at src/cregen.f90:2196
```

Any pure GFN‑FF QCG run that skips the RMSD/rotamer grouping step exhibits the same crash: `degen` is never populated, yet `cregen_conffile` dereferences `xyz(:,:,degen(2,i))`, so a zero index triggers the SIGSEGV.

## Summary

- Provide a trivial 1:1 group mapping whenever `sortRMSD` is false.
- Guard `cregen_conffile` against invalid group indices so we never read outside `[1, nall]`.

## Details

1. If the RMSD branch is bypassed, allocate `degen(:,i) = i` (or a single zeroed entry when the ensemble is empty).
2. In the writer, skip any group whose `degen(2,i)` falls outside the valid index range before calling `wrc0`.

## Testing

- CREST 3.0.2 (`c39758d`) + xtb 6.6.1
- The command above now completes the CREGEN stage without errors.