### PR TITLE
Add separate -TMD parallelization tag for the MTD stage

### DIFF
--- a/docs/man/crest.adoc
+++ b/docs/man/crest.adoc
@@ -89,6 +89,10 @@ If no such file is present as the first argument **crest** will automatically se
   Parallel settings are then determined automatically for each step.
   If not set by "`**-T**`", this number is read from the **OMP_NUM_THREADS** global variable.
 
+*-TMD* _int_::
+  Override the total number of CPUs (threads) to be used for MD/MTD sampling.
+  Other workflow steps continue to use the global **-T** thread budget.
+
 === Calculation options
 
 *-g* _string_::

--- a/src/algos/parallel.f90
+++ b/src/algos/parallel.f90
@@ -436,10 +436,11 @@ subroutine crest_search_multimd(env,mol,mddats,nsim)
   type(coord),allocatable :: moltmps(:)
   integer :: i,j,io,ich
   logical :: pr,ex,nested
-  integer :: T,Tn
+  integer :: T,Tn,Trestore,Tnrestore,thread_save
   real(wp) :: percent
   character(len=80) :: atmp
   character(len=*),parameter :: mdir = 'MDFILES'
+  logical :: use_tmd_threads
 
   type(calcdata),allocatable :: calculations(:)
   integer :: vz,job,thread_id
@@ -463,6 +464,9 @@ subroutine crest_search_multimd(env,mol,mddats,nsim)
   end if
 
 !>--- prepare calculation containers for parallelization (one per thread)
+  use_tmd_threads = env%threadsmdsetmanual.and.env%ThreadsMD > 0
+  thread_save = env%Threads
+  if (use_tmd_threads) env%Threads = env%ThreadsMD
   call new_ompautoset(env,'auto_nested',nsim,T,Tn) 
   nested = env%omp_allow_nested
 
@@ -538,6 +542,10 @@ subroutine crest_search_multimd(env,mol,mddats,nsim)
   call profiler%clear()
   deallocate (calculations)
   if (allocated(moltmps)) deallocate (moltmps)
+  if (use_tmd_threads) then
+    env%Threads = thread_save
+    call new_ompautoset(env,'max',0,Trestore,Tnrestore)
+  end if
   return
 contains
   subroutine collect(n,mddats)
@@ -744,10 +752,11 @@ subroutine crest_search_multimd2(env,mols,mddats,nsim)
   type(coord),allocatable :: moltmps(:)
   integer :: i,j,io,ich
   logical :: pr,ex,nested
-  integer :: T,Tn
+  integer :: T,Tn,Trestore,Tnrestore,thread_save
   real(wp) :: percent
   character(len=80) :: atmp
   character(len=*),parameter :: mdir = 'MDFILES'
+  logical :: use_tmd_threads
 
   type(calcdata),allocatable :: calculations(:)
   integer :: vz,job,thread_id
@@ -769,6 +778,9 @@ subroutine crest_search_multimd2(env,mols,mddats,nsim)
   end if
 
 !>--- prepare calculation objects for parallelization (one per thread)
+  use_tmd_threads = env%threadsmdsetmanual.and.env%ThreadsMD > 0
+  thread_save = env%Threads
+  if (use_tmd_threads) env%Threads = env%ThreadsMD
   call new_ompautoset(env,'auto_nested',nsim,T,Tn)
   nested = env%omp_allow_nested
 
@@ -837,6 +849,10 @@ subroutine crest_search_multimd2(env,mols,mddats,nsim)
   call profiler%clear()
   deallocate (calculations)
   if (allocated(moltmps)) deallocate (moltmps)
+  if (use_tmd_threads) then
+    env%Threads = thread_save
+    call new_ompautoset(env,'max',0,Trestore,Tnrestore)
+  end if
   return
 contains
   subroutine collect(n,mddats)

--- a/src/algos/search_conformers.f90
+++ b/src/algos/search_conformers.f90
@@ -109,6 +109,7 @@ subroutine crest_search_imtdgc(env,tim)
     write(stdout,'(1x,a,i0)') 'Meta-Dynamics Iteration ',i
     write(stdout,'(1x,a)') '------------------------------'
 
+    call env%ref%to(mol)
     nsim = -1 !>--- enambles automatic MTD setup in init routines
     call crest_search_multimd_init(env,mol,mddat,nsim)
     allocate (mddats(nsim), source=mddat)
@@ -619,5 +620,4 @@ subroutine crest_newcross3(env)
     enddo
   end do
 end subroutine crest_newcross3
-
 

--- a/src/algos/search_entropy.f90
+++ b/src/algos/search_entropy.f90
@@ -116,6 +116,7 @@ subroutine crest_search_entropy(env,tim)
       write (stdout,'(1x,a,i0)') 'Meta-Dynamics Iteration ',i
       write (stdout,'(1x,a)') '------------------------------'
 
+      call env%ref%to(mol)
       nsim = -1 !>--- enambles automatic MTD setup in init routines
       call crest_search_multimd_init(env,mol,mddat,nsim)
       allocate (mddats(nsim),source=mddat)
@@ -478,4 +479,3 @@ subroutine crest_init_multimd_smtd(env,mddats,nsim,biasfile)
   deallocate (eread,at,xyz)
   return
 end subroutine crest_init_multimd_smtd
-

--- a/src/classes.f90
+++ b/src/classes.f90
@@ -340,6 +340,7 @@ module crest_data
     integer :: MAXRUN = 1      !> number of cores per job
     integer :: omp = 1         !> OMP/MKL_NUM_THREADS
     integer :: Threads = 1     !> Total number of threads (=omp*MAXRUN)
+    integer :: ThreadsMD = 0   !> Optional total thread budget for MD/MTD only
     logical :: omp_allow_nested = .true.  !> allow nested OpenMP threadding
 
     !>--- various names and flags
@@ -569,6 +570,7 @@ module crest_data
     logical :: subRMSD               !> include only the selected substructure into the CREGEN RMSD
     logical :: superquick            !> very crude quick-run option
     logical :: threadssetmanual      !> are #CPUs set with the '-T' flag ?
+    logical :: threadsmdsetmanual    !> are #CPUs for MD/MTD set with '-TMD'?
     logical :: trackorigin           !> track the origin of a conformation?
     logical :: testnumgrad = .false. !> test numerical gradient in singlepoint
     logical :: use_xtbiff = .false.  !> use xtbiff for QCG?

--- a/src/confparse.f90
+++ b/src/confparse.f90
@@ -126,8 +126,10 @@ subroutine parseflags(env,arg,nra)
   env%Threads = 1                !> total number of threads
   env%MAXRUN = 1                 !> number of parallel xtb jobs
   env%omp = 1                    !> # of OMP_NUM_THREADS and MKL_NUMTHREADS to be used
+  env%ThreadsMD = 0              !> optional total number of threads for MD/MTD
   env%autothreads = .true.       !> automatically determine optimal parameters omp and MAXRUN
   env%threadssetmanual = .false. !> did the user set the #threads manually?
+  env%threadsmdsetmanual = .false. !> did the user set the #threads for MD/MTD manually?
 
   env%scratch = .false.          !> use scratch directory?
   call getcwd(env%homedir)       !> original directory
@@ -1447,6 +1449,13 @@ subroutine parseflags(env,arg,nra)
         env%threadssetmanual = .true.
         write (*,'(2x,a,1x,i0,1x,a)') trim(arg(i)),nint(xx(1)), &
         &     '(CPUs/Threads selected)'
+      case ('-TMD','-tmd') !> set total number of OMP threads for MD/MTD only
+        call readl(arg(i+1),xx,j)
+        if (index(arg(i+1),'-') .ne. 0) xx = 0d0
+        env%ThreadsMD = nint(xx(1))
+        env%threadsmdsetmanual = env%ThreadsMD > 0
+        write (*,'(2x,a,1x,i0,1x,a)') trim(arg(i)),nint(xx(1)), &
+        &     '(CPUs/Threads selected for MD/MTD)'
       case ('-inplace')     !> activate "in-place" mode for optimizations (ON by default)
         env%inplaceMode = .true.
 !========================================================================================!

--- a/src/legacy_algos/confscript2_misc.f90
+++ b/src/legacy_algos/confscript2_misc.f90
@@ -303,14 +303,17 @@ subroutine MetaMD_para_OMP(env)
 
   type(systemdata) :: env
 
-  integer :: i,vz,T,Tn
+  integer :: i,vz,T,Tn,Trestore,Tnrestore,thread_save
   real(wp) :: time
   character(len=512) :: thispath,tmppath
   character(len=512) :: jobcall
   character(len=80)  :: fname,pipe,atmp,btmp
   integer :: dum,io
-  logical :: ex
+  logical :: ex,use_tmd_threads
 
+  use_tmd_threads = env%threadsmdsetmanual.and.env%ThreadsMD > 0
+  thread_save = env%Threads
+  if (use_tmd_threads) env%Threads = env%ThreadsMD
   call new_ompautoset(env,'auto',env%nmetadyn,T,Tn)
 
   time = env%mdtime !for some reason this is necessary
@@ -381,6 +384,10 @@ subroutine MetaMD_para_OMP(env)
 
   if (.not.env%keepModef) then
     call cleanMTD
+  end if
+  if (use_tmd_threads) then
+    env%Threads = thread_save
+    call new_ompautoset(env,'max',0,Trestore,Tnrestore)
   end if
 
 end subroutine MetaMD_para_OMP

--- a/src/printouts.f90
+++ b/src/printouts.f90
@@ -151,6 +151,8 @@ subroutine confscript_morehelp(flag)
     write (*,'(5x,''                     determined automatically for each step.'')')
     write (*,'(5x,''                     If not set by "-T", this number is read'')')
     write (*,'(5x,''                     from the OMP_NUM_THREADS global variable.'')')
+    write (*,'(5x,''-TMD <int>         : Override total CPUs(threads) for MD/MTD only'')')
+    write (*,'(5x,''                     while keeping "-T" for other workflow steps.'')')
     write (*,'(5x,''-g <string>        : use GBSA implicit solvent'')')
     write (*,'(5x,''                     for solvent <string>'')')
     write (*,'(5x,''-alpb <string>     : use ALPB implicit solvent'')')
@@ -929,6 +931,9 @@ subroutine crest_dry(env)
     write (*,'(/,1x,a)') 'Technical settings'
     write (*,'(2x,a,a)') 'working directory : ',trim(dumstr)
     write (*,'(2x,a,i0)') 'CPUs (threads)     (-T) : ',env%threads
+    if (env%threadsmdsetmanual) then
+      write (*,'(2x,a,i0)') 'CPUs for MD/MTD  (-TMD) : ',env%ThreadsMD
+    end if
 
   end if
 


### PR DESCRIPTION
I found a small -T / parallel MTD CPU allocation issue in CREST 3.0.1 and made a minimal fix here.

In my CREST-NCI/GFN-FF tests, a large -T value was useful for the post-processing stage, but it also slowed down the MTD stage because the parallel MTD workers were not assigned CPU resources cleanly. This small fix adds an additional -TMD flag, allowing the number of CPU resources used for the MTD stage to be set separately from the global -T value. Since 3.1.0 is still being finalized, maybe this logic would be useful to port into the refactor.

For example, in my case -T 128 significantly accelerated post-processing because many conformers had to be handled, but it increased the MTD runtime from a few hours to days. On the other hand, -T 6 was optimal for running 6 GFN-FF MTD trajectories, but too slow for the conformer post-processing step. With the separate -TMD flag, both stages can use more appropriate CPU settings.